### PR TITLE
[Feature] Added proper pagination buttons to the customers page

### DIFF
--- a/app/(dashboard)/manage/customers/page.tsx
+++ b/app/(dashboard)/manage/customers/page.tsx
@@ -7,21 +7,31 @@ import { StaffRoleEnum } from '@/types/user';
 export default async function CustomersPage({
   searchParams,
 }: {
-  searchParams: Promise<{ search?: string }>
+  searchParams: Promise<{ search?: string; page?: string }>;
 }) {
+  const resolved = await searchParams;
+  const search = resolved.search || '';
+  const page = parseInt(resolved.page || '1', 10);
 
-  const search = (await searchParams).search || ''
-
-  const customers = await getCustomers(search);
+  const {
+    customers,
+    page: currentPage,
+    pages,
+    total
+  } = await getCustomers(search, page);
 
   return (
     <RoleProtected allowedRoles={[StaffRoleEnum.ADMIN]}>
-      <div className='flex'>
+      <div className="flex">
         <CustomerPage
-        searchTerm={search}
+          searchTerm={search}
           customers={customers}
+          currentPage={currentPage}
+          totalPages={pages}
+          totalCount={total}
         />
       </div>
     </RoleProtected>
   );
 }
+

--- a/components/Barbershop/AddAppointmentForm.tsx
+++ b/components/Barbershop/AddAppointmentForm.tsx
@@ -64,7 +64,7 @@ export default function AddAppointmentForm({
       try {
         setIsLoadingCustomers(true);
         const customerData = await getCustomers();
-        setCustomers(customerData);
+        setCustomers(customerData.customers);
       } catch (error) {
         console.error("Error fetching customers:", error);
         toast({ status: "error", description: "Failed to load customers" });

--- a/components/Barbershop/Appointments.tsx
+++ b/components/Barbershop/Appointments.tsx
@@ -82,7 +82,7 @@ export default function AppointmentsPage() {
       try {
         setIsLoadingCustomers(true);
         const customerData = await getCustomers();
-        setCustomers(customerData);
+        setCustomers(customerData.customers);
       } catch (error) {
         console.error("Error fetching customers:", error);
       } finally {

--- a/components/customers/CustomerTable.tsx
+++ b/components/customers/CustomerTable.tsx
@@ -296,55 +296,7 @@ export default function CustomerTable({
           </TableBody>
         </Table>
       </div>
-      <div className="bg-muted/30 px-6 py-4 border-t rounded-b-xl">
-        <div className="flex items-center justify-between">
-          <div className="text-sm text-muted-foreground">
-            Showing <span className="font-semibold">{table.getRowModel().rows.length}</span> of{" "}
-            <span className="font-semibold">{table.getFilteredRowModel().rows.length}</span>{" "}
-            customers
-          </div>
-          <div className="flex items-center space-x-6">
-            <div className="flex items-center space-x-2">
-              <span className="text-sm text-muted-foreground">Rows per page:</span>
-              <Select
-                value={String(table.getState().pagination.pageSize)}
-                onValueChange={(value) => table.setPageSize(Number(value))}
-              >
-                <SelectTrigger className="h-8 w-[70px]">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent className="border">
-                  {[5, 10, 20, 50, 100].map((size) => (
-                    <SelectItem key={size} value={String(size)} className="text-sm">
-                      {size}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-            <div className="flex space-x-2">
-              <Button
-                variant="outline"
-                size="sm"
-                className="border hover:bg-accent hover:text-accent-foreground"
-                onClick={() => table.previousPage()}
-                disabled={!table.getCanPreviousPage()}
-              >
-                Previous
-              </Button>
-              <Button
-                variant="outline"
-                size="sm"
-                className="border hover:bg-accent hover:text-accent-foreground"
-                onClick={() => table.nextPage()}
-                disabled={!table.getCanNextPage()}
-              >
-                Next
-              </Button>
-            </div>
-          </div>
-        </div>
-      </div>
+
     </div>
   );
 }


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
-  Replaced the old prev and next buttons with proper buttons using pagination
- 
- 

---

# 🧠 Reason for Changes

we need this because the buttons would only display 20 customers without dynamically getting other pages from the API response

now when we click next or prev the api will get called with the corresponding page number. it also shows the total count of customers and what page they are currently on

---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [X] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [ ] Backend APIs tested via Postman
- [X] No console errors (Frontend)
- [ ] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---

# 📸 Screenshots or Screen Recording (Optional)

<!-- Attach screenshots or recordings if visual/UI changes were made -->

---

# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
https://trello.com/c/DYY8WX85/188-display-more-customers-properly-only-displays-20

---

# 🗒️ Notes for Reviewer (Optional)

<!-- Anything special to highlight, known issues, extra context, etc. -->

