### PR TITLE
Show membership plan price

### DIFF
--- a/services/membershipPlan.ts
+++ b/services/membershipPlan.ts
@@ -1,0 +1,31 @@
+import getValue from "@/configs/constants";
+import { MembershipPlanPlanResponse } from "@/app/api/Api";
+import { MembershipPlan } from "@/types/membership";
+
+export async function getPlansForMembership(membershipId: string): Promise<MembershipPlan[]> {
+  try {
+    const res = await fetch(`${getValue("API")}memberships/${membershipId}/plans`);
+
+    if (!res.ok) {
+      const errorText = await res.text();
+      console.error(`❌ Failed to fetch plans:`, res.status, errorText);
+      throw new Error("Could not load membership plans");
+    }
+
+    const data: MembershipPlanPlanResponse[] = await res.json();
+
+    return data.map((plan) => ({
+      id: plan.id!,
+      membership_id: plan.membership_id!,
+      name: plan.name || "Unnamed Plan",
+      stripe_price_id: plan.stripe_price_id || "",
+      stripe_joining_fees_id: plan.stripe_joining_fees_id || "",
+      amt_periods: plan.amt_periods || 0,
+      price: (plan as any).price ?? 0,
+      joining_fee: (plan as any).joining_fee ?? 0,
+    }));
+  } catch (err) {
+    console.error("🔥 Error loading membership plans:", err);
+    throw err;
+  }
+}

--- a/types/membership.ts
+++ b/types/membership.ts
@@ -13,6 +13,10 @@ export interface MembershipPlan {
   stripe_price_id: string;
   stripe_joining_fees_id?: string;
   amt_periods: number;
+  /** Price in cents or dollars as returned by the API */
+  price?: number;
+  /** Joining fee amount if available */
+  joining_fee?: number;
 }
 
 export interface MembershipPlanRequestDto {


### PR DESCRIPTION
## Summary
- extend `MembershipPlan` type with price fields
- add service to fetch membership plans with prices
- show formatted price instead of Stripe IDs on membership plan list
- update form inputs to use price and joining fee

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6849a4149e948321bdcf11b115ec2aac