### PR TITLE
[Chore] Fixed membership plans so it shows price instead of stripe id

### DIFF
--- a/components/memberships/infoTabs/plans/Plans.tsx
+++ b/components/memberships/infoTabs/plans/Plans.tsx
@@ -5,6 +5,7 @@ import { useToast } from "@/hooks/use-toast";
 import { useUser } from "@/contexts/UserContext";
 import getValue from "@/configs/constants";
 import { MembershipPlan } from "@/types/membership";
+import { getPlansForMembership } from "@/services/membershipPlan";
 
 export default function PlansTab({ membershipId }: { membershipId: string }) {
   const { user } = useUser();
@@ -17,20 +18,21 @@ export default function PlansTab({ membershipId }: { membershipId: string }) {
   const [editablePlans, setEditablePlans] = useState<any>({});
   const [newperiod, setnewperiod] = useState<any>();
   const [newname, setnewname] = useState<string>("");
-  const [newstripeid, setnewstripeid] = useState<string>("");
-  const [newstripejoinfee, setnewstripejoinfee] = useState<any>();
+  const [newprice, setnewprice] = useState<string>("");
+  const [newjoiningfee, setnewjoiningfee] = useState<string>("");
   const [newplantoggle, setnewplantoggle] = useState(false);
 
   const [plans, setPlans] = useState<MembershipPlan[]>([]);
 
+  const formatPrice = (price: number) =>
+    new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: "CAD",
+    }).format(price);
+
   const fetchPlans = async () => {
     try {
-      const response = await fetch(
-        `${apiUrl}memberships/${membershipId}/plans`
-      );
-      if (!response.ok) throw new Error("Failed to fetch membership plans");
-
-      const plansData = await response.json();
+      const plansData = await getPlansForMembership(membershipId);
       setPlans(plansData);
     } catch (error) {
       console.error("Error fetching plans:", error);
@@ -84,7 +86,7 @@ export default function PlansTab({ membershipId }: { membershipId: string }) {
   // add new plan
   const addnewplan = async () => {
     // verify no null enters
-    if (!newname || !newstripeid || !newperiod) {
+    if (!newname || !newprice || !newperiod) {
       toast({
         status: "error",
         description:
@@ -116,8 +118,8 @@ export default function PlansTab({ membershipId }: { membershipId: string }) {
         body: JSON.stringify({
           membership_id: membershipId,
           name: newname,
-          stripe_price_id: newstripeid,
-          stripe_joining_fees_id: newstripejoinfee,
+          price: parseFloat(newprice),
+          joining_fee: newjoiningfee ? parseFloat(newjoiningfee) : undefined,
           amt_periods: parsedPeriod,
         }),
       });
@@ -134,8 +136,8 @@ export default function PlansTab({ membershipId }: { membershipId: string }) {
         });
         refreshPlans();
         setnewname("");
-        setnewstripeid("");
-        setnewstripejoinfee("");
+        setnewprice("");
+        setnewjoiningfee("");
         setnewperiod("");
         setnewplantoggle(false);
       }
@@ -171,8 +173,10 @@ export default function PlansTab({ membershipId }: { membershipId: string }) {
           body: JSON.stringify({
             membership_id: membershipId,
             name: updatedPlan.name,
-            stripe_price_id: updatedPlan.stripe_price_id,
-            stripe_joining_fees_id: updatedPlan.stripe_joining_fees_id,
+            price: parseFloat(updatedPlan.price),
+            joining_fee: updatedPlan.joining_fee
+              ? parseFloat(updatedPlan.joining_fee)
+              : undefined,
             amt_periods: parsedPeriod,
           }),
         }
@@ -239,10 +243,10 @@ export default function PlansTab({ membershipId }: { membershipId: string }) {
                   <h1>{plan.name}</h1>
                   <div className="flex">
                     <h1 className="font-semibold text-sm pt-1 text-stone-500 pr-1">
-                      Stripe ID
+                      Price
                     </h1>
                     <h1 className="text-stone-500 font-medium text-sm pt-1 pr-1">
-                      {plan.stripe_price_id}
+                      {plan.price ?? 0}
                     </h1>
                     <h1 className="text-stone-500 font-semibold text-sm pt-1">
                       • Every {plan.amt_periods} Months
@@ -263,38 +267,32 @@ export default function PlansTab({ membershipId }: { membershipId: string }) {
                     />
                   </div>
                   <div className="w-full pl-1 ">
-                    <Label className="w-full"> Stripe Price ID </Label>
+                    <Label className="w-full"> Price </Label>
                     <Input
                       className="w-full mt-1"
                       onChange={(e) =>
-                        handleInputChange(
-                          plan.id,
-                          "stripe_price_id",
-                          e.target.value
-                        )
+                        handleInputChange(plan.id, "price", e.target.value)
                       }
-                      value={editablePlans[plan.id]?.stripe_price_id || ""}
-                      placeholder={plan.stripe_price_id}
+                      value={editablePlans[plan.id]?.price || ""}
+                      placeholder={plan.price?.toString()}
                       onClick={(e) => e.stopPropagation()}
                     />
                   </div>
                 </div>
                 <div className="pt-3 flex">
                   <div className="w-full pr-5">
-                    <Label className="w-full"> Stripe Joining Fee ID </Label>
+                    <Label className="w-full">Joining Fee</Label>
                     <Input
                       className="w-full mt-1"
                       onChange={(e) =>
                         handleInputChange(
                           plan.id,
-                          "stripe_joining_fees_id",
+                          "joining_fee",
                           e.target.value
                         )
                       }
-                      value={
-                        editablePlans[plan.id]?.stripe_joining_fees_id || ""
-                      }
-                      placeholder={plan.stripe_joining_fees_id}
+                      value={editablePlans[plan.id]?.joining_fee || ""}
+                      placeholder={plan.joining_fee?.toString()}
                       onClick={(e) => e.stopPropagation()}
                     />
                   </div>
@@ -351,10 +349,10 @@ export default function PlansTab({ membershipId }: { membershipId: string }) {
                 <h1>{plan.name}</h1>
                 <div className="flex">
                   <h1 className="font-semibold text-sm pt-1 text-stone-500 pr-1">
-                    Stripe ID
+                    Price
                   </h1>
                   <h1 className="text-stone-500 font-medium text-sm pt-1 pr-1">
-                    {plan.stripe_price_id}
+                    {formatPrice(plan.price ?? 0)}
                   </h1>
                   <h1 className="text-stone-500 font-semibold text-sm pt-1">
                     • Every {plan.amt_periods} Months
@@ -384,24 +382,24 @@ export default function PlansTab({ membershipId }: { membershipId: string }) {
                 />
               </div>
               <div className="w-full pl-1 ">
-                <Label className="w-full"> Stripe Price ID </Label>
+                <Label className="w-full">Price</Label>
                 <Input
                   className="w-full mt-1"
-                  value={newstripeid ?? ""}
-                  onChange={(e) => setnewstripeid(e.target.value)}
-                  placeholder="stripe subscription payment id"
+                  value={newprice ?? ""}
+                  onChange={(e) => setnewprice(e.target.value)}
+                  placeholder="0"
                   onClick={(e) => e.stopPropagation()}
                 />
               </div>
             </div>
             <div className="pt-3 flex">
               <div className="w-full pr-5">
-                <Label className="w-full"> Stripe Joining Fee ID </Label>
+                <Label className="w-full">Joining Fee</Label>
                 <Input
                   className="w-full mt-1"
-                  value={newstripejoinfee ?? ""}
-                  onChange={(e) => setnewstripejoinfee(e.target.value)}
-                  placeholder="stripe fee id"
+                  value={newjoiningfee ?? ""}
+                  onChange={(e) => setnewjoiningfee(e.target.value)}
+                  placeholder="0"
                   onClick={(e) => e.stopPropagation()}
                 />
               </div>

--- a/services/membershipPlan.ts
+++ b/services/membershipPlan.ts
@@ -1,0 +1,35 @@
+import getValue from "@/configs/constants";
+import { MembershipPlanPlanResponse } from "@/app/api/Api";
+import { MembershipPlan } from "@/types/membership";
+
+export async function getPlansForMembership(
+  membershipId: string
+): Promise<MembershipPlan[]> {
+  try {
+    const res = await fetch(
+      `${getValue("API")}memberships/${membershipId}/plans`
+    );
+
+    if (!res.ok) {
+      const errorText = await res.text();
+      console.error(`❌ Failed to fetch plans:`, res.status, errorText);
+      throw new Error("Could not load membership plans");
+    }
+
+    const data: MembershipPlanPlanResponse[] = await res.json();
+
+    return data.map((plan) => ({
+      id: plan.id!,
+      membership_id: plan.membership_id!,
+      name: plan.name || "Unnamed Plan",
+      stripe_price_id: plan.stripe_price_id || "",
+      stripe_joining_fees_id: plan.stripe_joining_fees_id || "",
+      amt_periods: plan.amt_periods || 0,
+      price: (plan as any).price ?? 0,
+      joining_fee: (plan as any).joining_fee ?? 0,
+    }));
+  } catch (err) {
+    console.error("🔥 Error loading membership plans:", err);
+    throw err;
+  }
+}

--- a/types/membership.ts
+++ b/types/membership.ts
@@ -13,6 +13,8 @@ export interface MembershipPlan {
   stripe_price_id: string;
   stripe_joining_fees_id?: string;
   amt_periods: number;
+  price?: number;
+  joining_fee?: number;
 }
 
 export interface MembershipPlanRequestDto {


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
- Added membership Plan service
- Added price and joining fee to membership plan type
- Switched all stripe id relates items to price

---

# 🧠 Reason for Changes

<!-- Explain why this change was necessary -->
- Centralizing the API logic with getPlansForMembership provides a single, reusable way to retrieve plan data for any component
- Including price and joining_fee fields in the MembershipPlan interface lets the UI hold actual monetary values rather than only Stripe IDs
- The Plans component now formats and displays each plan’s price instead of showing the stripe_price_id, making the costs clear to users
---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [X] Frontend tested locally (`npm run dev`)
- [X] No console errors (Frontend)

---

# 📸 Screenshots or Screen Recording (Optional)

<!-- Attach screenshots or recordings if visual/UI changes were made -->
![image](https://github.com/user-attachments/assets/fa6d12f9-f836-45e7-b70d-28648af1a329)

---

# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
- https://trello.com/c/DXIZOXGf/176-fix-memberships-so-in-plans-it-shows-price-and-not-id

---

# 🗒️ Notes for Reviewer (Optional)

<!-- Anything special to highlight, known issues, extra context, etc. -->
- I think we will need to add joining fee to the backend
