### PR TITLE
[Chore] Fixed sidebar styling / breadcrumb 

### DIFF
--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -32,16 +32,11 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   // Build nav items based on role
   const navMain = [
     {
-      title: "Home",
+      title: "Dashboard",
       url: "/",
       icon: <HomeIcon width={20} height={15} />,
       isActive: true,
       items: [
-        {
-          title: "Dashboard",
-          url: "/",
-          icon: <HomeIcon width={15} height={15} />,
-        },
         // Everyone with access can see Calendar
         {
           title: "Calendar",

--- a/hooks/use-breadcrumbs.tsx
+++ b/hooks/use-breadcrumbs.tsx
@@ -19,51 +19,55 @@ const routeMapping: Record<string, BreadcrumbItem[]> = {
 
   // Manage
   "/manage/customers": [
-    { title: "Home", link: "/" },
+    { title: "Dashboard", link: "/" },
     { title: "Customers", link: "/manage/customers" },
   ],
   "/manage/courses": [
-    { title: "Home", link: "/" },
+    { title: "Dashboard", link: "/" },
     { title: "Courses", link: "/manage/courses" },
   ],
   "/manage/store": [
-    { title: "Home", link: "/" },
+    { title: "Dashboard", link: "/" },
     { title: "Store", link: "/manage/store" },
   ],
   "/manage/facilities": [
-    { title: "Home", link: "/" },
+    { title: "Dashboard", link: "/" },
     { title: "Facilities", link: "/manage/facilities" },
   ],
   "/manage/instructors": [
-    { title: "Home", link: "/" },
+    { title: "Dashboard", link: "/" },
     { title: "Instructors", link: "/manage/instructors" },
   ],
   "/manage/trainer": [
-    { title: "Home", link: "/" },
+    { title: "Dashboard", link: "/" },
     { title: "Trainer", link: "/manage/trainer" },
   ],
   "/manage/membership": [
-    { title: "Home", link: "/" },
+    { title: "Dashboard", link: "/" },
     { title: "Membership", link: "/manage/membership" },
   ],
   "/manage/teams": [
-    { title: "Home", link: "/" },
+    { title: "Dashboard", link: "/" },
     { title: "Teams", link: "/manage/teams" },
+  ],
+  "/manage/playgorund": [
+    { title: "Dashboard", link: "/" },
+    { title: "Playground", link: "/manage/playground" },
   ],
 
   // Automation
   "/automation/messages": [
-    { title: "Home", link: "/" },
+    { title: "Dashboard", link: "/" },
     { title: "Messages", link: "/automation/messages" },
   ],
 
   // Reports
   "/reports/transactions": [
-    { title: "Home", link: "/" },
+    { title: "Dashboard", link: "/" },
     { title: "Transactions", link: "/reports/transactions" },
   ],
   "/reports/financials": [
-    { title: "Home", link: "/" },
+    { title: "Dashboard", link: "/" },
     { title: "Financials", link: "/reports/financials" },
   ],
 };
@@ -77,13 +81,17 @@ export function useBreadcrumbs() {
     }
     // Fall back to auto-generating if not in routeMapping
     const segments = pathname.split("/").filter(Boolean);
-    return segments.map((segment, index) => {
-      const path = `/${segments.slice(0, index + 1).join("/")}`;
-      return {
-        title: segment.charAt(0).toUpperCase() + segment.slice(1),
-        link: path,
-      };
-    });
+    const page = segments.pop();
+    const title = page
+      ? page.charAt(0).toUpperCase() + page.slice(1)
+      : "Dashboard";
+    if (!page) {
+      return [{ title: "Dashboard", link: "/" }];
+    }
+    return [
+      { title: "Dashboard", link: "/" },
+      { title, link: pathname },
+    ];
   }, [pathname]);
 
   return breadcrumbs;


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
- Changed sidebar so dashboard and home are now one link
- Fixed breadcrumb so it will say Dashboard then the current page
- Changed auto generated breadcrumb to dashboard instead of manage

---

# 🧠 Reason for Changes

<!-- Explain why this change was necessary -->
- Made one link for home and dashboard so UX looks better
- Fixed breadcrumb since some said manage and some said dashboard, now it is consistent 
- Changed the auto generated bread crumb so if there is not one set up it will be consistent with the rest of the pages instead of saying manage then the page name 
---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [X] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [ ] Backend APIs tested via Postman
- [X] No console errors (Frontend)
- [ ] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---

# 📸 Screenshots or Screen Recording (Optional)

<!-- Attach screenshots or recordings if visual/UI changes were made -->
![image](https://github.com/user-attachments/assets/fb4fb846-cf4d-447c-aced-59804b50b965)

---

# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
- https://trello.com/c/pYS0uDMu/196-fix-sidebar-styling

---



