### PR TITLE
[Chore] Added delete functionality to the playground page

### DIFF
--- a/components/Playground/PlaygroundPage.tsx
+++ b/components/Playground/PlaygroundPage.tsx
@@ -79,7 +79,9 @@ export default function PlaygroundPage({
   // Drawer close handlers
   const handleAddBooking = () => setDrawerOpen(false);
   const handleUpdateBooking = () => setDrawerOpen(false);
-  const handleDeleteBooking = () => setDrawerOpen(false);
+  const handleDeleteBooking = (id: string) => {
+    setDrawerOpen(false);
+  };
 
   return (
     <div className="flex-1 space-y-4 p-6 pt-6">


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
- Added to playground page
- Added to booking info panel page


---

# 🧠 Reason for Changes

<!-- Explain why this change was necessary -->
- handleDeleteBooking now accepts a session ID so it can be called from BookingInfoPanel after a successful deletion, allowing the drawer to close properly

- The delete button now invokes deletePlaygroundSession with user credentials and shows toast notifications, ensuring bookings are removed on the server and the UI is updated accordingly
---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [X] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [ ] Backend APIs tested via Postman
- [X] No console errors (Frontend)
- [ ] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---



# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
- https://trello.com/c/oDmeHUme/212-fix-playground-delete

---



