### PR TITLE
[Chore] Made staff editable in info panel / drawer 

### DIFF
--- a/components/staff/StaffPage.tsx
+++ b/components/staff/StaffPage.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import columnsStaff from "@/components/staff/columnsStaff";
 import { Sheet, SheetContent } from "@/components/ui/sheet";
+import RightDrawer from "../reusable/RightDrawer";
 import { VisibilityState } from "@tanstack/react-table";
 
 export default function StaffPage({ staffs }: { staffs: User[] }) {
@@ -130,22 +131,22 @@ export default function StaffPage({ staffs }: { staffs: User[] }) {
         onColumnVisibilityChange={setColumnVisibility}
       />
 
-      {/* Drawer (sheet) for editing or adding staff */}
-      <Sheet
-        open={drawerOpen}
-        onOpenChange={(open) => {
-          if (!open) handleDrawerClose();
-        }}
-      >
-        <SheetContent className="w-full sm:max-w-md md:max-w-xl overflow-y-auto pb-0">
-          {isNewStaff ? (
-            <StaffForm />
-          ) : selectedStaff ? (
-            // Render form for editing the selected staff
-            <StaffForm StaffData={selectedStaff} />
-          ) : null}
-        </SheetContent>
-      </Sheet>
+      {/* Drawer for editing or adding staff */}
+      {drawerOpen && (
+        <RightDrawer
+          drawerOpen={drawerOpen}
+          handleDrawerClose={handleDrawerClose}
+          drawerWidth="w-[700px]"
+        >
+          <div className="p-4">
+            {isNewStaff ? (
+              <StaffForm />
+            ) : selectedStaff ? (
+              <StaffForm StaffData={selectedStaff} />
+            ) : null}
+          </div>
+        </RightDrawer>
+      )}
     </div>
   );
 }

--- a/services/staff.ts
+++ b/services/staff.ts
@@ -157,3 +157,32 @@ export async function approveStaff(id: string, jwt: string): Promise<void> {
     throw error;
   }
 }
+
+export async function updateStaff(
+  id: string,
+  staffData: StaffRequestDto,
+  jwt: string
+): Promise<string | null> {
+  try {
+    const response = await fetch(`${getValue("API")}staffs/${id}`, {
+      method: "PUT",
+      ...addAuthHeader(jwt),
+      body: JSON.stringify(staffData),
+    });
+
+    const responseJSON = await response.json().catch(() => ({}));
+
+    if (!response.ok) {
+      let errorMessage = `Failed to update staff: ${response.statusText}`;
+      if (responseJSON.error) {
+        errorMessage = responseJSON.error.message;
+      }
+      return errorMessage;
+    }
+
+    return null;
+  } catch (error) {
+    console.error("Error updating staff:", error);
+    return error instanceof Error ? error.message : "Unknown error occurred";
+  }
+}

--- a/services/user.ts
+++ b/services/user.ts
@@ -1,0 +1,41 @@
+import { UserUpdateRequestDto } from "@/app/api/Api";
+import getValue from "@/configs/constants";
+import { addAuthHeader } from "@/lib/auth-header";
+
+export async function updateUser(
+  id: string,
+  userData: UserUpdateRequestDto,
+  jwt: string
+): Promise<string | null> {
+  try {
+    const payload: UserUpdateRequestDto = { ...userData };
+    if (payload.phone) {
+      const digits = payload.phone.replace(/\D/g, "");
+      payload.phone = digits.startsWith("1") ? `+${digits}` : `+1${digits}`;
+    }
+
+    const response = await fetch(`${getValue("API")}users/${id}`, {
+      method: "PUT",
+      ...addAuthHeader(jwt),
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      const responseJSON = await response.json().catch(() => ({}));
+      let errorMessage = `Failed to update user: ${response.statusText}`;
+
+      if (responseJSON.error) {
+        errorMessage = responseJSON.error.message;
+      } else if (responseJSON.message) {
+        errorMessage = responseJSON.message;
+      }
+
+      return errorMessage;
+    }
+
+    return null;
+  } catch (error) {
+    console.error("Error updating user:", error);
+    return error instanceof Error ? error.message : "Unknown error occurred";
+  }
+}


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
- Changed Staff Form
- Changed Staff Page
- Changed staff services 
- Added User services
---

# 🧠 Reason for Changes

<!-- Explain why this change was necessary -->
- Changed Staff Form – The form now includes editable fields for personal details and calls new update helpers so staff data can be saved in one place using the drawer UI.
- Changed Staff Page – The page uses the RightDrawer component to open a consistent side drawer for editing, matching how customer records are modified.
- Changed staff services – A new updateStaff function was added to handle PUT requests to /staffs/{id}, enabling updates to role and active status via the staff API.
- Added User services – A dedicated updateUser service sends the rest of the staff profile fields to the /users endpoint, separating account updates from role and status changes.
---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [X] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [ ] Backend APIs tested via Postman
- [X] No console errors (Frontend)
- [ ] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---



# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
- https://trello.com/c/sIYLElA3/218-make-staff-editable

---



