### PR TITLE
[Chore] Fix adding a team. Coach select instead of entering ID 

### DIFF
--- a/components/teams/AddTeamForm.tsx
+++ b/components/teams/AddTeamForm.tsx
@@ -5,12 +5,22 @@
 
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { useUser } from "@/contexts/UserContext";
 import { useToast } from "@/hooks/use-toast";
 import { useFormData } from "@/hooks/form-data";
 import { createTeam } from "@/services/teams";
+import { getAllStaffs } from "@/services/staff";
 import { TeamRequestDto } from "@/app/api/Api";
 import { revalidateTeams } from "@/actions/serverActions";
+import { User } from "@/types/user";
+import { useEffect, useState } from "react";
 
 export default function AddTeamForm({ onClose }: { onClose?: () => void }) {
   // useFormData provides a simple object based form state manager
@@ -22,6 +32,25 @@ export default function AddTeamForm({ onClose }: { onClose?: () => void }) {
   });
   const { user } = useUser();
   const { toast } = useToast();
+  const [coaches, setCoaches] = useState<User[]>([]);
+
+  useEffect(() => {
+    const fetchCoaches = async () => {
+      try {
+        const coachData = await getAllStaffs("COACH");
+        setCoaches(coachData);
+      } catch (error) {
+        toast({
+          status: "error",
+          description:
+            error instanceof Error ? error.message : "Failed to load coaches",
+          variant: "destructive",
+        });
+      }
+    };
+
+    fetchCoaches();
+  }, [toast]);
 
   // Submit handler that validates input and calls the createTeam API.
   // If successful it resets the form and optionally closes the drawer.
@@ -92,13 +121,22 @@ export default function AddTeamForm({ onClose }: { onClose?: () => void }) {
         </div>
 
         <div className="space-y-2">
-          <label className="text-sm font-medium">Coach ID</label>
-          <Input
+          <label className="text-sm font-medium">Coach</label>
+          <Select
             value={data.coach_id}
-            onChange={(e) => updateField("coach_id", e.target.value)}
-            type="text"
-            placeholder="Coach ID (optional)"
-          />
+            onValueChange={(id) => updateField("coach_id", id)}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="Select Coach" />
+            </SelectTrigger>
+            <SelectContent>
+              {coaches.map((c) => (
+                <SelectItem key={c.ID} value={c.ID}>
+                  {c.Name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
         </div>
       </div>
 

--- a/services/teams.ts
+++ b/services/teams.ts
@@ -72,9 +72,8 @@ export async function createTeam(
       body: JSON.stringify(teamData),
     });
 
-    const responseJSON = await response.json();
-
     if (!response.ok) {
+      const responseJSON = await response.json().catch(() => ({}));
       let errorMessage = `Failed to create team: ${response.statusText}`;
       if (responseJSON.error) {
         errorMessage = responseJSON.error.message;


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
- Changed teams service
- Changed add team form

---

# 🧠 Reason for Changes

<!-- Explain why this change was necessary -->
- Changed teams service: The createTeam function was updated to safely handle empty JSON responses so that team creation doesn’t crash with a SyntaxError when the API body is empty.

- Changed add team form: The form now fetches available coaches and provides a dropdown for selection, replacing the free‑text input to avoid invalid coach IDs.
---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [X] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [ ] Backend APIs tested via Postman
- [X] No console errors (Frontend)
- [ ] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---



# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
- https://trello.com/c/B7fe7jFe/220-add-coaches-select-when-adding-a-team

---

