### PR TITLE
[Chore] Fixed team DELETE error

### DIFF
--- a/services/teams.ts
+++ b/services/teams.ts
@@ -194,7 +194,13 @@ export async function deleteTeam(
       ...addAuthHeader(jwt),
     });
 
-    const responseJSON = await response.json();
+    const text = await response.text();
+    let responseJSON: any = {};
+    if (text) {
+      try {
+        responseJSON = JSON.parse(text);
+      } catch {}
+    }
 
     if (!response.ok) {
       let errorMessage = `Failed to delete team: ${response.statusText}`;


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
- Changed responseJSON 

---

# 🧠 Reason for Changes

<!-- Explain why this change was necessary -->
- The deletion API sometimes returns a 204 No Content response, so deleteTeam now reads the body as text and only parses it when content exists, preventing response.json() from throwing a syntax error when the body is empty
---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [X] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [ ] Backend APIs tested via Postman
- [X] No console errors (Frontend)
- [ ] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---



# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
- https://trello.com/c/pUxXi4rF/211-fix-error-when-deleting-team

---



