### PR TITLE
[Chore] Fixed adding / editing a membership plans

### DIFF
--- a/components/memberships/infoTabs/plans/Plans.tsx
+++ b/components/memberships/infoTabs/plans/Plans.tsx
@@ -118,8 +118,8 @@ export default function PlansTab({ membershipId }: { membershipId: string }) {
         body: JSON.stringify({
           membership_id: membershipId,
           name: newname,
-          price: parseFloat(newprice),
-          joining_fee: newjoiningfee ? parseFloat(newjoiningfee) : undefined,
+          stripe_price_id: newprice,
+          stripe_joining_fees_id: newjoiningfee ? newjoiningfee : undefined,
           amt_periods: parsedPeriod,
         }),
       });
@@ -173,9 +173,9 @@ export default function PlansTab({ membershipId }: { membershipId: string }) {
           body: JSON.stringify({
             membership_id: membershipId,
             name: updatedPlan.name,
-            price: parseFloat(updatedPlan.price),
-            joining_fee: updatedPlan.joining_fee
-              ? parseFloat(updatedPlan.joining_fee)
+            stripe_price_id: updatedPlan.price,
+            stripe_joining_fees_id: updatedPlan.joining_fee
+              ? updatedPlan.joining_fee
               : undefined,
             amt_periods: parsedPeriod,
           }),


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
- Changed PUT and POST so they will work when creating or updating a plan
---

# 🧠 Reason for Changes

<!-- Explain why this change was necessary -->
- The update ensures that POST and PUT requests for creating or editing membership plans send stripe_price_id and stripe_joining_fees_id instead of numeric price fields so that the payload matches the API’s expected schema, preventing the previous 400 Bad Request errors.
---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [X] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [ ] Backend APIs tested via Postman
- [X] No console errors (Frontend)
- [ ] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---

# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
- https://trello.com/c/mhCFMP43/208-fix-creating-membership-plan-add

---


