### PR TITLE
[Chore] Changed updateTeam to prevent JSON parsing errors

### DIFF
--- a/services/teams.ts
+++ b/services/teams.ts
@@ -100,7 +100,7 @@ export async function updateTeam(
       body: JSON.stringify(teamData),
     });
 
-    const responseJSON = await response.json();
+    const responseJSON = await response.json().catch(() => ({}));
 
     if (!response.ok) {
       let errorMessage = `Failed to update team: ${response.statusText}`;


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
- Changed updateTeam JSON response

---

# 🧠 Reason for Changes

<!-- Explain why this change was necessary -->
- The change to updateTeam ensures that empty server responses no longer cause a JSON parsing error, preventing the “Unexpected end of JSON input” exception that occurred when editing a team
---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [X] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [ ] Backend APIs tested via Postman
- [X] No console errors (Frontend)
- [ ] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---

# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
- https://trello.com/c/8U6WiycI/210-fix-errors-when-edit-team

---



