### PR TITLE
[Feature] Practice table now shows who booked the practice based on User

### DIFF
--- a/components/practices/PracticeInfoPanel.tsx
+++ b/components/practices/PracticeInfoPanel.tsx
@@ -133,6 +133,11 @@ export default function PracticeInfoPanel({
 
   return (
     <div className="space-y-6">
+      {practice.booked_by && (
+        <p className="text-sm text-muted-foreground">
+          Booked By: {practice.booked_by}
+        </p>
+      )}
       <div className="space-y-4">
         <div className="space-y-2">
           <label className="text-sm font-medium">Team</label>

--- a/components/practices/table/columns.tsx
+++ b/components/practices/table/columns.tsx
@@ -45,6 +45,14 @@ const columns: ColumnDef<Practice>[] = [
     minSize: 180,
     size: 220,
   },
+  {
+    id: "booked_by",
+    accessorKey: "booked_by",
+    header: "Booked By",
+    cell: ({ row }) => row.getValue("booked_by") || "-",
+    minSize: 150,
+    size: 200,
+  },
 ];
 
 export default columns;

--- a/services/practices.ts
+++ b/services/practices.ts
@@ -10,7 +10,10 @@ import {
 
 // Retrieve all practice events between very wide date ranges
 export async function getAllPractices(): Promise<Practice[]> {
-  const response = await fetch(`${getValue("API")}practices`);
+  const token = localStorage.getItem("jwt");
+  const response = await fetch(`${getValue("API")}practices`, {
+    headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+  });
   const resJson = await response.json();
 
   if (!response.ok) {
@@ -31,6 +34,9 @@ export async function getAllPractices(): Promise<Practice[]> {
     location_name: p.location_name ?? "",
     team_id: p.team_id,
     team_name: p.team_name,
+    booked_by: p.created_by
+      ? `${p.created_by.first_name} ${p.created_by.last_name}`
+      : (p.booked_by ?? ""),
     start_at: p.start_time,
     end_at: p.end_time,
     capacity: 0,

--- a/types/practice.ts
+++ b/types/practice.ts
@@ -8,6 +8,7 @@ export interface Practice {
   location_name: string;
   team_id?: string;
   team_name?: string;
+  booked_by?: string;
   start_at: string;
   end_at: string;
   capacity: number;


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
- Changed Practice info panel 
- Changed table columns 
- Added to practice service and type 

---

# 🧠 Reason for Changes

<!-- Explain why this change was necessary -->
- Added a paragraph to conditionally display practice.booked_by, letting users see who booked the practice session in the info panel
- Inserted a “Booked By” column so the practices table lists which coach booked each practice
- The service now sends an auth header and parses the booking coach from the API, while the Practice type includes a booked_by field so this data can be stored and shown
---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [X] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [ ] Backend APIs tested via Postman
- [X] No console errors (Frontend)
- [ ] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---



# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
- https://trello.com/c/0K7QTsa4/233-add-a-booked-by-column-to-practice-table

---



