### PR TITLE
[Chore] Merge Location and Court Pages into new Facilities Page

### DIFF
--- a/actions/serverActions.ts
+++ b/actions/serverActions.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from "next/cache";
 
 export async function revalidateLocations() {
   revalidatePath("/manage/locations");
+  revalidatePath("/manage/facilities");
 }
 
 export async function revalidatePrograms() {
@@ -40,4 +41,5 @@ export async function revalidatePractices() {
 
 export async function revalidateCourts() {
   revalidatePath("/manage/courts");
+  revalidatePath("/manage/facilities");
 }

--- a/app/(dashboard)/manage/facilities/page.tsx
+++ b/app/(dashboard)/manage/facilities/page.tsx
@@ -1,0 +1,28 @@
+import FacilitiesPage from "@/components/locations/LocationPage";
+import CourtPage from "@/components/courts/CourtPage";
+import RoleProtected from "@/components/RoleProtected";
+import { getAllLocations } from "@/services/location";
+import { getAllCourts } from "@/services/court";
+import { StaffRoleEnum } from "@/types/user";
+
+export default async function Page() {
+  const [locations, courts] = await Promise.all([
+    getAllLocations(),
+    getAllCourts(),
+  ]);
+
+  const courtsWithNames = courts.map((court) => ({
+    ...court,
+    location_name:
+      locations.find((l) => l.id === court.location_id)?.name || "",
+  }));
+
+  return (
+    <RoleProtected allowedRoles={[StaffRoleEnum.ADMIN]}>
+      <div className="flex flex-col">
+        <FacilitiesPage facilities={locations} />
+        <CourtPage courts={courtsWithNames} />
+      </div>
+    </RoleProtected>
+  );
+}

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -71,8 +71,8 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                 icon: <List width={15} height={15} />,
               },
               {
-                title: "Locations",
-                url: "/manage/locations",
+                title: "Facilities",
+                url: "/manage/facilities",
                 icon: <MapPin width={15} height={15} />,
               },
               {


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
- Added to server actions
- Created new facilities page
- Changed sidebar

---

# 🧠 Reason for Changes

<!-- Explain why this change was necessary -->
- Added to server actions - The project now revalidates /manage/facilities whenever locations or courts change so the combined Facilities page stays up‑to‑date

- Created new facilities page - A new server component fetches both locations and courts, merges location names into court data, and renders the existing Locations and Courts components together on one page

- Changed sidebar - The sidebar navigation entry formerly titled “Locations” now reads “Facilities” and points to /manage/facilities for direct access to the combined view
---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [X] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [ ] Backend APIs tested via Postman
- [X] No console errors (Frontend)
- [ ] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---

# 📸 Screenshots or Screen Recording 

<!-- Attach screenshots or recordings if visual/UI changes were made -->
<img width="1336" height="839" alt="image" src="https://github.com/user-attachments/assets/40dbe795-b1b9-4ef5-99a6-1e2633e027c5" />

---

# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
- https://trello.com/c/hbDJN1kN/237-merge-locations-and-courts-page

---


