### PR TITLE
[Chore] Merged Barbershop and Playground into Amenities

### DIFF
--- a/app/(dashboard)/manage/amenities/page.tsx
+++ b/app/(dashboard)/manage/amenities/page.tsx
@@ -1,0 +1,60 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import BarbershopPage from "@/components/Barbershop/BarberPage";
+import PlaygroundPage from "@/components/Playground/PlaygroundPage";
+import RoleProtected from "@/components/RoleProtected";
+import { StaffRoleEnum } from "@/types/user";
+import { getAllStaffs } from "@/services/staff";
+import {
+  getPlaygroundSessions,
+  getPlaygroundSystems,
+} from "@/services/playground";
+
+export default async function AmenitiesPageContainer() {
+  const [staffs, sessions, systems] = await Promise.all([
+    getAllStaffs(StaffRoleEnum.BARBER.toUpperCase()),
+    getPlaygroundSessions(),
+    getPlaygroundSystems(),
+  ]);
+
+  return (
+    <RoleProtected
+      allowedRoles={[StaffRoleEnum.ADMIN, StaffRoleEnum.BARBER]}
+      fallback={<PageSkeleton />}
+    >
+      <div className="flex flex-col">
+        <BarbershopPage staffs={staffs} />
+        <PlaygroundPage sessions={sessions} systems={systems} />
+      </div>
+    </RoleProtected>
+  );
+}
+
+function PageSkeleton() {
+  return (
+    <div className="flex-1 space-y-4 p-6 pt-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <Skeleton className="h-8 w-64" />
+          <Skeleton className="h-4 w-48 mt-2" />
+        </div>
+        <Skeleton className="h-10 w-32" />
+      </div>
+
+      <Skeleton className="h-px w-full" />
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4">
+        {[1, 2, 3, 4].map((i) => (
+          <Skeleton key={i} className="h-24 w-full rounded-lg" />
+        ))}
+      </div>
+
+      <div className="flex gap-4 mt-4">
+        {[1, 2, 3].map((i) => (
+          <Skeleton key={i} className="h-10 w-36" />
+        ))}
+      </div>
+
+      <Skeleton className="h-96 w-full mt-8 rounded-lg" />
+    </div>
+  );
+}

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -101,22 +101,9 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                 icon: <Dribbble width={15} height={15} />,
               },
               {
-                title: "Playground",
-                url: "/manage/playground",
+                title: "Amenities",
+                url: "/manage/amenities",
                 icon: <Gamepad2 width={15} height={15} />,
-              },
-            ]
-          : []),
-
-        // Barbers and SuperAdmin can see Barbershop
-        ...(role == StaffRoleEnum.BARBER ||
-        role == StaffRoleEnum.SUPERADMIN ||
-        role == StaffRoleEnum.ADMIN
-          ? [
-              {
-                title: "Barbershop",
-                url: "/manage/barbershop",
-                icon: <Scissors width={15} height={15} />,
               },
             ]
           : []),


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
- Added amenities page
- Changed sidebar 

---

# 🧠 Reason for Changes

<!-- Explain why this change was necessary -->
- Added amenities page - This new page consolidates the barbershop and playground content under one route, so admins can manage both amenities in a single place instead of navigating to separate pages

- Changed sidebar - The sidebar now links directly to the new “Amenities” page (and no longer shows separate Barbershop or Playground items) to keep navigation consistent with the page merge
---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [X] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [ ] Backend APIs tested via Postman
- [X] No console errors (Frontend)
- [ ] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---



# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
- https://trello.com/c/VjdtGmUw/239-merge-playground-and-barber-shop-into-amenties-using-column-layout

---



