### PR TITLE
[Chore] Fixed Calendar event info panel, added edit functionality 

### DIFF
--- a/components/calendar/dialog/calendar-manage-event-drawer.tsx
+++ b/components/calendar/dialog/calendar-manage-event-drawer.tsx
@@ -1,9 +1,9 @@
-"use client"
+"use client";
 
-import { useEffect, useState } from "react"
-import * as React from "react"
+import { useEffect, useState } from "react";
+import * as React from "react";
 
-import { Button } from "@/components/ui/button"
+import { Button } from "@/components/ui/button";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -14,16 +14,11 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
   AlertDialogTrigger,
-} from "@/components/ui/alert-dialog"
-import { Separator } from "@/components/ui/separator"
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import { CheckCircle2, XCircle } from "lucide-react"
-import RightDrawer from "@/components/reusable/RightDrawer"
-import { useCalendarContext } from "../calendar-context"
-import AttendeesTable from "./manage/AttendeesTable"
-import { getEvent } from "@/services/events"
-import { EventParticipant } from "@/types/events"
-
+} from "@/components/ui/alert-dialog";
+import { Separator } from "@/components/ui/separator";
+import RightDrawer from "@/components/reusable/RightDrawer";
+import { useCalendarContext } from "../calendar-context";
+import EditEventForm from "../event/EditEventForm";
 
 export default function CalendarManageEventDrawer() {
   const {
@@ -33,232 +28,118 @@ export default function CalendarManageEventDrawer() {
     setSelectedEvent,
     events,
     setEvents,
-  } = useCalendarContext()
+  } = useCalendarContext();
 
-  const [showEditForm, setShowEditForm] = useState(false)
-  const [event, setEvent] = useState(selectedEvent)
-
-  const [participants, setParticipants] = useState<EventParticipant[]>([])
-
-  useEffect(() => {
-    async function fetchData() {
-      if (selectedEvent) {
-
-        const event = await getEvent(selectedEvent.id)
-
-        setEvent(selectedEvent)
-        setParticipants(event.customers)
-      }
-    }
-
-    fetchData()
-  }, [selectedEvent])
-
-  const bookedAttendees = participants.filter((attendee) => !attendee.has_cancelled_enrollment)
-  const cancelledAttendees = participants.filter((attendee) => attendee.has_cancelled_enrollment)
+  const [showEditForm, setShowEditForm] = useState(false);
 
   function handleDelete() {
-    if (!selectedEvent) return
-    setEvents(events.filter((event) => event.id !== selectedEvent.id))
-    handleClose()
+    if (!selectedEvent) return;
+    setEvents(events.filter((event) => event.id !== selectedEvent.id));
+    handleClose();
   }
 
   function handleClose() {
-    setManageEventDialogOpen(false)
-    setSelectedEvent(null)
+    setManageEventDialogOpen(false);
+    setSelectedEvent(null);
     // form.reset()
-    setShowEditForm(false)
+    setShowEditForm(false);
   }
 
   return (
     <RightDrawer
       drawerOpen={manageEventDialogOpen}
       handleDrawerClose={handleClose}
-      drawerWidth="w-[75%]"
+      drawerWidth="w-[40%]"
     >
-      <div className="flex h-full">
-        {/* Left Section (70%) */}
-        <div className="w-[70%] border-r">
-          <Tabs defaultValue="booked" className="w-full">
-            {/* Tab List now shows the actual count */}
-            <TabsList className="w-full h-auto p-0 bg-transparent flex gap-1">
-              <TabsTrigger
-                value="booked"
-                className="flex items-center gap-2 px-6 py-3 data-[state=active]:border-b-2 data-[state=active]:border-primary data-[state=active]:text-primary data-[state=active]:shadow-none rounded-none bg-transparent hover:bg-muted/50 transition-all"
-              >
-                <CheckCircle2 className="h-4 w-4" />
-                {bookedAttendees.length} Booked
-              </TabsTrigger>
-              <TabsTrigger
-                value="cancelled"
-                className="flex items-center gap-2 px-6 py-3 data-[state=active]:border-b-2 data-[state=active]:border-primary data-[state=active]:text-primary data-[state=active]:shadow-none rounded-none bg-transparent hover:bg-muted/50 transition-all"
-              >
-                <XCircle className="h-4 w-4" />
-                {cancelledAttendees.length} Cancelled
-              </TabsTrigger>
-            </TabsList>
-
-            {/* Booked Attendees Table */}
-            <TabsContent value="booked" className="mt-2">
-              <AttendeesTable data={bookedAttendees} />
-            </TabsContent>
-
-            {/* Cancelled Attendees Table */}
-            <TabsContent value="cancelled" className="mt-2">
-              <AttendeesTable data={cancelledAttendees} />
-            </TabsContent>
-          </Tabs>
-        </div>
-
-        {/* Right Section */}
-        <div className="w-[30%] p-6 space-y-6">
-          <h1 className="text-xl font-semibold">
-            {selectedEvent?.program.name || "Unnamed Event"}
-          </h1>
-          <p className="text-base text-muted-foreground">
-            Date: {selectedEvent?.start_at.toLocaleDateString("en-US", {
-              weekday: "long",
-              year: "numeric",
-              month: "long",
-              day: "numeric",
-            })}
-          </p>
-
-          <p className="text-base text-muted-foreground">
-            Start Time: {selectedEvent?.start_at.toLocaleTimeString("en-US", {
-              hour: "2-digit",
-              minute: "2-digit",
-            })}
-          </p>
-          <p className="text-base text-muted-foreground">
-
-            End Time: {selectedEvent?.end_at.toLocaleTimeString("en-US", {
-              hour: "2-digit",
-              minute: "2-digit",
-            })}
-          </p>
-          <p className="text-base text-muted-foreground">
-            {selectedEvent?.location.name}          </p>
-          <p className="text-base text-muted-foreground">{selectedEvent?.location.address}</p>
-
-          <Separator />
-
-          <div className="space-y-4">
-            <Button variant="default" className="w-full">
-              Book Member
-            </Button>
-            <Button
-              variant="outline"
-              className="w-full"
-              onClick={() => setShowEditForm(!showEditForm)}
-            >
-              Edit this Event
-            </Button>
-
-            <AlertDialog>
-              <AlertDialogTrigger asChild>
-                <Button variant="destructive" className="w-full">
-                  Delete
-                </Button>
-              </AlertDialogTrigger>
-              <AlertDialogContent>
-                <AlertDialogHeader>
-                  <AlertDialogTitle>Confirm Deletion</AlertDialogTitle>
-                  <AlertDialogDescription>
-                    Are you sure you want to delete this event? This action cannot be undone.
-                  </AlertDialogDescription>
-                </AlertDialogHeader>
-                <AlertDialogFooter>
-                  <AlertDialogCancel>Cancel</AlertDialogCancel>
-                  <AlertDialogAction onClick={handleDelete}>
-                    Confirm Delete
-                  </AlertDialogAction>
-                </AlertDialogFooter>
-              </AlertDialogContent>
-            </AlertDialog>
-
-            <Button variant="outline" className="w-full">
-              Send Group Message
-            </Button>
-            <Button variant="outline" className="w-full">
-              Check-in Everyone
-            </Button>
-            <Button variant="outline" className="w-full">
-              Download CSV
-            </Button>
-          </div>
-
-          {/* {showEditForm && (
-            <div className="mt-6 space-y-6">
+      {selectedEvent && (
+        <div className="p-6 space-y-6">
+          {showEditForm ? (
+            <EditEventForm onClose={handleClose} />
+          ) : (
+            <>
+              <h1 className="text-xl font-semibold">
+                {selectedEvent.program.name || "Unnamed Event"}
+              </h1>
+              <p className="text-base text-muted-foreground">
+                Date:{" "}
+                {selectedEvent.start_at.toLocaleDateString("en-US", {
+                  weekday: "long",
+                  year: "numeric",
+                  month: "long",
+                  day: "numeric",
+                })}
+              </p>
+              <p className="text-base text-muted-foreground">
+                Start Time:{" "}
+                {selectedEvent.start_at.toLocaleTimeString("en-US", {
+                  hour: "2-digit",
+                  minute: "2-digit",
+                })}
+              </p>
+              <p className="text-base text-muted-foreground">
+                End Time:{" "}
+                {selectedEvent.end_at.toLocaleTimeString("en-US", {
+                  hour: "2-digit",
+                  minute: "2-digit",
+                })}
+              </p>
+              <p className="text-base text-muted-foreground">
+                {selectedEvent.location.name}
+              </p>
+              <p className="text-base text-muted-foreground">
+                {selectedEvent.location.address}
+              </p>
+              {selectedEvent.team?.name && (
+                <p className="text-base text-muted-foreground">
+                  Team: {selectedEvent.team.name}
+                </p>
+              )}
+              {((selectedEvent as any).court_name ||
+                (selectedEvent as any).court ||
+                (selectedEvent as any).court?.name) && (
+                <p className="text-base text-muted-foreground">
+                  Court:{" "}
+                  {(selectedEvent as any).court_name ||
+                    (selectedEvent as any).court?.name ||
+                    (selectedEvent as any).court}
+                </p>
+              )}
               <Separator />
-              <h2 className="text-lg font-semibold">Edit Event</h2>
-              <Form {...form}>
-                <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
-                  <FormField
-                    control={form.control}
-                    name="title"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>Title</FormLabel>
-                        <FormControl>
-                          <Input {...field} />
-                        </FormControl>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-
-                  <FormField
-                    control={form.control}
-                    name="start"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>Start</FormLabel>
-                        <FormControl>
-                          <DateTimePicker field={field} />
-                        </FormControl>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-
-                  <FormField
-                    control={form.control}
-                    name="end"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>End</FormLabel>
-                        <FormControl>
-                          <DateTimePicker field={field} />
-                        </FormControl>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-
-                  <FormField
-                    control={form.control}
-                    name="color"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>Color</FormLabel>
-                        <FormControl>
-                          <ColorPicker field={field} />
-                        </FormControl>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-
-                  <Button className="w-full" type="submit">
-                    Update Event
-                  </Button>
-                </form>
-              </Form>
-            </div>
-          )} */}
+              <div className="space-y-4">
+                <Button
+                  variant="outline"
+                  className="w-full"
+                  onClick={() => setShowEditForm(true)}
+                >
+                  Edit this Event
+                </Button>
+                <AlertDialog>
+                  <AlertDialogTrigger asChild>
+                    <Button variant="destructive" className="w-full">
+                      Delete
+                    </Button>
+                  </AlertDialogTrigger>
+                  <AlertDialogContent>
+                    <AlertDialogHeader>
+                      <AlertDialogTitle>Confirm Deletion</AlertDialogTitle>
+                      <AlertDialogDescription>
+                        Are you sure you want to delete this event? This action
+                        cannot be undone.
+                      </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                      <AlertDialogCancel>Cancel</AlertDialogCancel>
+                      <AlertDialogAction onClick={handleDelete}>
+                        Confirm Delete
+                      </AlertDialogAction>
+                    </AlertDialogFooter>
+                  </AlertDialogContent>
+                </AlertDialog>
+              </div>
+            </>
+          )}
         </div>
-      </div>
+      )}
     </RightDrawer>
-  )
+  );
 }

--- a/components/calendar/event/EditEventForm.tsx
+++ b/components/calendar/event/EditEventForm.tsx
@@ -1,0 +1,269 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { SaveIcon } from "lucide-react";
+import { useUser } from "@/contexts/UserContext";
+import { useToast } from "@/hooks/use-toast";
+import { updateEvent } from "@/services/events";
+import { EventCreateRequest } from "@/types/events";
+import { getAllPrograms } from "@/services/program";
+import { getAllTeams } from "@/services/teams";
+import { getAllLocations } from "@/services/location";
+import { getAllCourts } from "@/services/court";
+import { Program } from "@/types/program";
+import { Team } from "@/types/team";
+import { Location } from "@/types/location";
+import { Court } from "@/types/court";
+import { revalidateEvents } from "@/actions/serverActions";
+import { useCalendarContext } from "../calendar-context";
+import { CalendarEvent } from "@/types/calendar";
+import { colorOptions } from "@/components/calendar/calendar-tailwind-classes";
+
+function getColorFromProgramType(programType?: string): string {
+  switch (programType) {
+    case "course":
+      return colorOptions[2].value;
+    case "tournament":
+      return colorOptions[0].value;
+    case "tryouts":
+      return colorOptions[1].value;
+    case "event":
+      return colorOptions[3].value;
+    case "game":
+      return colorOptions[0].value;
+    case "practice":
+      return colorOptions[1].value;
+    default:
+      return "gray";
+  }
+}
+
+export default function EditEventForm({ onClose }: { onClose?: () => void }) {
+  const { user } = useUser();
+  const { toast } = useToast();
+  const { selectedEvent, setEvents, events } = useCalendarContext();
+
+  const [programs, setPrograms] = useState<Program[]>([]);
+  const [teams, setTeams] = useState<Team[]>([]);
+  const [locations, setLocations] = useState<Location[]>([]);
+  const [courts, setCourts] = useState<Court[]>([]);
+
+  const [data, setData] = useState({
+    program_id: "",
+    team_id: "",
+    location_id: "",
+    court_id: "",
+    start_at: "",
+    end_at: "",
+  });
+
+  const filteredCourts = courts.filter(
+    (c) => c.location_id === data.location_id
+  );
+
+  useEffect(() => {
+    const fetchLists = async () => {
+      try {
+        const [progs, tms, locs, crts] = await Promise.all([
+          getAllPrograms("all"),
+          getAllTeams(),
+          getAllLocations(),
+          getAllCourts(),
+        ]);
+        setPrograms(progs);
+        setTeams(tms);
+        setLocations(locs);
+        setCourts(crts);
+      } catch (err) {
+        console.error("Failed to fetch dropdown data", err);
+      }
+    };
+
+    fetchLists();
+  }, []);
+
+  useEffect(() => {
+    if (selectedEvent) {
+      setData({
+        program_id: selectedEvent.program.id,
+        team_id: selectedEvent.team?.id || "",
+        location_id: selectedEvent.location.id,
+        court_id:
+          (selectedEvent as any).court?.id ||
+          (selectedEvent as any).court_id ||
+          "",
+        start_at: new Date(selectedEvent.start_at).toISOString().slice(0, 16),
+        end_at: new Date(selectedEvent.end_at).toISOString().slice(0, 16),
+      });
+    }
+  }, [selectedEvent]);
+
+  const handleUpdate = async () => {
+    if (!selectedEvent) return;
+    if (!data.program_id || !data.location_id) {
+      toast({
+        status: "error",
+        description: "Program and location are required",
+        variant: "destructive",
+      });
+      return;
+    }
+    if (!data.start_at || !data.end_at) {
+      toast({
+        status: "error",
+        description: "Start and end time are required",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    const eventData: EventCreateRequest = {
+      program_id: data.program_id,
+      team_id: data.team_id || undefined,
+      location_id: data.location_id,
+      court_id: data.court_id ? data.court_id : null,
+      start_at: new Date(data.start_at).toISOString(),
+      end_at: new Date(data.end_at).toISOString(),
+    };
+
+    const error = await updateEvent(selectedEvent.id, eventData, user?.Jwt!);
+
+    if (error === null) {
+      toast({ status: "success", description: "Event updated successfully" });
+      await revalidateEvents();
+      const program = programs.find((p) => p.id === data.program_id);
+      const location = locations.find((l) => l.id === data.location_id);
+      const team = teams.find((t) => t.id === data.team_id);
+      const court = courts.find((c) => c.id === data.court_id);
+      const nameParts = (user?.Name || " ").split(" ");
+      const firstName = nameParts.shift() || "";
+      const lastName = nameParts.join(" ");
+      const updatedEvent: CalendarEvent = {
+        ...selectedEvent,
+        color: getColorFromProgramType(program?.type),
+        start_at: new Date(data.start_at),
+        end_at: new Date(data.end_at),
+        program: {
+          id: program?.id || "",
+          name: program?.name || "",
+          type: program?.type || "",
+        },
+        location: {
+          id: location?.id || "",
+          name: location?.name || "",
+          address: location?.address || "",
+        },
+        court: court ? { id: court.id, name: court.name } : undefined,
+        team: { id: team?.id || "", name: team?.name || "" },
+        updatedBy: { id: user?.ID || "", firstName, lastName },
+      };
+      setEvents(
+        events.map((e) => (e.id === updatedEvent.id ? updatedEvent : e))
+      );
+      if (onClose) onClose();
+    } else {
+      toast({
+        status: "error",
+        description: `Failed to update event: ${error}`,
+        variant: "destructive",
+      });
+    }
+  };
+
+  return (
+    <div className="space-y-6 pt-3">
+      <div className="space-y-4">
+        <div className="space-y-2">
+          <label className="text-sm font-medium">Program</label>
+          <select
+            className="w-full border rounded-md p-2"
+            value={data.program_id}
+            onChange={(e) => setData({ ...data, program_id: e.target.value })}
+          >
+            <option value="" disabled>
+              Select program
+            </option>
+            {programs.map((p) => (
+              <option key={p.id} value={p.id}>
+                {p.name}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="space-y-2">
+          <label className="text-sm font-medium">Team (optional)</label>
+          <select
+            className="w-full border rounded-md p-2"
+            value={data.team_id}
+            onChange={(e) => setData({ ...data, team_id: e.target.value })}
+          >
+            <option value="">Select team</option>
+            {teams.map((team) => (
+              <option key={team.id} value={team.id}>
+                {team.name}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="space-y-2">
+          <label className="text-sm font-medium">Location</label>
+          <select
+            className="w-full border rounded-md p-2"
+            value={data.location_id}
+            onChange={(e) => {
+              setData({ ...data, location_id: e.target.value, court_id: "" });
+            }}
+          >
+            <option value="" disabled>
+              Select location
+            </option>
+            {locations.map((loc) => (
+              <option key={loc.id} value={loc.id}>
+                {loc.name}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="space-y-2">
+          <label className="text-sm font-medium">Court (optional)</label>
+          <select
+            className="w-full border rounded-md p-2"
+            value={data.court_id}
+            onChange={(e) => setData({ ...data, court_id: e.target.value })}
+          >
+            <option value="">Select Court</option>
+            {filteredCourts.map((court) => (
+              <option key={court.id} value={court.id}>
+                {court.name}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="space-y-2">
+          <label className="text-sm font-medium">Start Time</label>
+          <Input
+            value={data.start_at}
+            onChange={(e) => setData({ ...data, start_at: e.target.value })}
+            type="datetime-local"
+          />
+        </div>
+        <div className="space-y-2">
+          <label className="text-sm font-medium">End Time</label>
+          <Input
+            value={data.end_at}
+            onChange={(e) => setData({ ...data, end_at: e.target.value })}
+            type="datetime-local"
+          />
+        </div>
+      </div>
+      <Button
+        onClick={handleUpdate}
+        className="w-full bg-green-600 hover:bg-green-700"
+      >
+        <SaveIcon className="h-4 w-4 mr-2" /> Save Event
+      </Button>
+    </div>
+  );
+}

--- a/types/calendar.ts
+++ b/types/calendar.ts
@@ -1,28 +1,28 @@
 export type CalendarProps = {
-  events: CalendarEvent[]
-  setEvents: (events: CalendarEvent[]) => void
-  mode: Mode
-  setMode: (mode: Mode) => void
-  date: Date
-  setDate: (date: Date) => void
-  calendarIconIsToday?: boolean
-  onEventSelect?: (event: CalendarEvent) => void  // Added this line
-}
+  events: CalendarEvent[];
+  setEvents: (events: CalendarEvent[]) => void;
+  mode: Mode;
+  setMode: (mode: Mode) => void;
+  date: Date;
+  setDate: (date: Date) => void;
+  calendarIconIsToday?: boolean;
+  onEventSelect?: (event: CalendarEvent) => void; // Added this line
+};
 
 export type CalendarContextType = CalendarProps & {
-  newEventDialogOpen: boolean
-  setNewEventDialogOpen: (open: boolean) => void
-  manageEventDialogOpen: boolean
-  setManageEventDialogOpen: (open: boolean) => void
-  selectedEvent: CalendarEvent | null
-  setSelectedEvent: (event: CalendarEvent | null) => void
-  onEventSelect?: (event: CalendarEvent) => void  // Added this line
-}
+  newEventDialogOpen: boolean;
+  setNewEventDialogOpen: (open: boolean) => void;
+  manageEventDialogOpen: boolean;
+  setManageEventDialogOpen: (open: boolean) => void;
+  selectedEvent: CalendarEvent | null;
+  setSelectedEvent: (event: CalendarEvent | null) => void;
+  onEventSelect?: (event: CalendarEvent) => void; // Added this line
+};
 // types/calendar.ts
 export interface CalendarEvent {
   id: string;
-  start_at: Date
-  end_at: Date
+  start_at: Date;
+  end_at: Date;
   capacity: number;
   color?: string;
   createdBy: {
@@ -41,6 +41,10 @@ export interface CalendarEvent {
   }>;
   location: {
     address: string;
+    id: string;
+    name: string;
+  };
+  court?: {
     id: string;
     name: string;
   };
@@ -69,10 +73,9 @@ export interface CalendarEvent {
   };
 }
 
-export const calendarModes = ['day', 'week', 'month'] as const
-export type Mode = (typeof calendarModes)[number]
+export const calendarModes = ["day", "week", "month"] as const;
+export type Mode = (typeof calendarModes)[number];
 
-    
 // If you have existing Trainer/Class/Facility types, keep them:
 export interface Trainer {
   coach_stats: {
@@ -97,7 +100,7 @@ export interface FiltersType {
   // Date filters
   after: string; // YYYY-MM-DD
   before: string; // YYYY-MM-DD
-  
+
   // Backend API filter params - single selections (legacy)
   program_id?: string;
   user_id?: string;
@@ -108,7 +111,7 @@ export interface FiltersType {
   updated_by?: string;
 
   // New multi-select options
-  location_ids?: string[];  // Multiple locations
-  user_ids?: string[];      // Multiple trainers/users
-  program_ids?: string[];   // Multiple programs
+  location_ids?: string[]; // Multiple locations
+  user_ids?: string[]; // Multiple trainers/users
+  program_ids?: string[]; // Multiple programs
 }


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
- Changed calendar event drawer
- Created Edit event form
- Added to calendar types 

---

# 🧠 Reason for Changes

<!-- Explain why this change was necessary -->
- Changed calendar event drawer - The drawer was simplified to immediately show all relevant event details and provide quick access to an edit option, matching the user’s request to see only the information needed to manage an event.

- Created Edit event form - A dedicated form component was implemented so events could be updated via the correct API endpoint while showing success or error toasts.

- Added to calendar types - The CalendarEvent type was extended with an optional court object to properly store court information returned from the backend and used when editing or creating events.
---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [X] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [ ] Backend APIs tested via Postman
- [X] No console errors (Frontend)
- [ ] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---



# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
- https://trello.com/c/dZwI5w20/248-fix-events-when-clicking-on-them-from-the-calendar-page
- https://trello.com/c/OX8WGfCK/249-edit-event-on-calendar-page

---

# 🗒️ Notes for Reviewer (Optional)

<!-- Anything special to highlight, known issues, extra context, etc. -->
- 2 Trello cards completed 
