### PR TITLE
[Chore] Added delete functionality to the events on the calendar page

### DIFF
--- a/services/events.ts
+++ b/services/events.ts
@@ -279,6 +279,33 @@ export async function deleteEventsByRecurrenceID(id: string, jwt: string) {
   }
 }
 
+export async function deleteEvent(
+  id: string,
+  jwt: string
+): Promise<string | null> {
+  try {
+    const response = await fetch(`${getValue("API")}events`, {
+      method: "DELETE",
+      ...addAuthHeader(jwt),
+      body: JSON.stringify({ ids: [id] }),
+    });
+
+    if (!response.ok) {
+      const resJson = await response.json();
+      let errorMessage = `Failed to delete event: ${response.statusText}`;
+      if (resJson.error) {
+        errorMessage = resJson.error.message;
+      }
+      return errorMessage;
+    }
+
+    return null;
+  } catch (error) {
+    console.error("Error deleting event:", error);
+    return error instanceof Error ? error.message : "Unknown error occurred";
+  }
+}
+
 export async function getSchedulesOfProgram(
   programID: string
 ): Promise<EventSchedule[]> {


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
- Changed event drawer
- Added Delete to events service 

---

# 🧠 Reason for Changes

<!-- Explain why this change was necessary -->
- Changed event drawer - Updated the calendar manage event drawer so that deleting an event calls the new API helper, shows success or error toasts, and refreshes the event list for accurate UI updates.

- Added Delete to events service - Introduced a deleteEvent helper in services/events.ts that makes an authenticated DELETE request to the /events endpoint, allowing events to be removed on the server.
---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [X] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [ ] Backend APIs tested via Postman
- [X] No console errors (Frontend)
- [ ] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---



# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
- https://trello.com/c/eETj5UrQ/250-delete-event-on-calendar-page

---


