### PR TITLE
[Chore] Fixed Customers page so it will refresh automatically after CRUD operations 

### DIFF
--- a/app/(dashboard)/manage/customers/page.tsx
+++ b/app/(dashboard)/manage/customers/page.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import CustomerPage from "@/components/customers/CustomerPage";
+import CustomersManager from "@/components/customers/CustomersManager";
 import { getCustomers, getArchivedCustomers } from "@/services/customer";
 import RoleProtected from "@/components/RoleProtected";
 import { StaffRoleEnum } from "@/types/user";
@@ -17,36 +17,25 @@ export default async function CustomersPage({
     customers,
     page: currentPage,
     pages,
-    total,
   } = await getCustomers(search, page);
 
   const {
     customers: archivedCustomers,
     page: archivedCurrentPage,
     pages: archivedPages,
-    total: archivedTotal,
   } = await getArchivedCustomers(search, page);
 
   return (
     <RoleProtected allowedRoles={[StaffRoleEnum.ADMIN]}>
-      <div className="flex flex-col">
-        <CustomerPage
-          searchTerm={search}
-          customers={customers}
-          currentPage={currentPage}
-          totalPages={pages}
-          totalCount={total}
-        />
-        <CustomerPage
-          title="Archived Customers"
-          isArchivedList
-          searchTerm={search}
-          customers={archivedCustomers}
-          currentPage={archivedCurrentPage}
-          totalPages={archivedPages}
-          totalCount={archivedTotal}
-        />
-      </div>
+      <CustomersManager
+        search={search}
+        customers={customers}
+        archivedCustomers={archivedCustomers}
+        currentPage={currentPage}
+        pages={pages}
+        archivedCurrentPage={archivedCurrentPage}
+        archivedPages={archivedPages}
+      />
     </RoleProtected>
   );
 }

--- a/components/customers/CustomerInfoPanel.tsx
+++ b/components/customers/CustomerInfoPanel.tsx
@@ -31,7 +31,7 @@ interface MembershipPlan {
 
 interface CustomerInfoPanelProps {
   customer: Customer;
-  onCustomerUpdated?: () => void;
+  onCustomerUpdated?: (updated: Partial<Customer>) => void;
   onCustomerArchived?: (id: string) => Promise<void> | void;
 }
 
@@ -105,12 +105,27 @@ export default function CustomerInfoPanel({
       if (!user) return;
       if (currentCustomer.is_archived) {
         await unarchiveCustomer(currentCustomer.id, user.Jwt);
+        setCurrentCustomer((prev) => ({ ...prev, is_archived: false }));
+        toast({
+          status: "success",
+          description: "Customer successfully unarchived",
+        });
       } else {
         await archiveCustomer(currentCustomer.id, user.Jwt);
+        setCurrentCustomer((prev) => ({ ...prev, is_archived: true }));
+        toast({
+          status: "success",
+          description: "Customer successfully archived",
+        });
       }
       onCustomerArchived?.(currentCustomer.id);
     } catch (error) {
       console.error("Error archiving customer:", error);
+      toast({
+        status: "error",
+        description: "Error archiving customer",
+        variant: "destructive",
+      });
     }
   };
 
@@ -169,7 +184,7 @@ export default function CustomerInfoPanel({
             customer={currentCustomer}
             onCustomerUpdated={(updated) => {
               setCurrentCustomer((prev) => ({ ...prev, ...updated }));
-              onCustomerUpdated?.();
+              onCustomerUpdated?.(updated);
               toast({
                 status: "success",
                 description: "Customer information updated",

--- a/components/customers/CustomersManager.tsx
+++ b/components/customers/CustomersManager.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useState } from "react";
+import CustomerPage from "./CustomerPage";
+import { Customer } from "@/types/customer";
+import { archiveCustomer, unarchiveCustomer } from "@/services/customer";
+import { useUser } from "@/contexts/UserContext";
+import { useToast } from "@/hooks/use-toast";
+
+interface CustomersManagerProps {
+  search: string;
+  customers: Customer[];
+  archivedCustomers: Customer[];
+  currentPage: number;
+  pages: number;
+  archivedCurrentPage: number;
+  archivedPages: number;
+}
+
+export default function CustomersManager({
+  search,
+  customers,
+  archivedCustomers,
+  currentPage,
+  pages,
+  archivedCurrentPage,
+  archivedPages,
+}: CustomersManagerProps) {
+  const [activeList, setActiveList] = useState<Customer[]>(customers);
+  const [archivedList, setArchivedList] =
+    useState<Customer[]>(archivedCustomers);
+
+  const { user } = useUser();
+  const { toast } = useToast();
+
+  const handleArchive = async (id: string) => {
+    if (!user) return;
+    await archiveCustomer(id, user.Jwt);
+    setActiveList((prev) => prev.filter((c) => c.id !== id));
+    const moved = activeList.find((c) => c.id === id);
+    if (moved) {
+      setArchivedList((prev) => [{ ...moved, is_archived: true }, ...prev]);
+    }
+    toast({ status: "success", description: "Customer successfully archived" });
+  };
+
+  const handleUnarchive = async (id: string) => {
+    if (!user) return;
+    await unarchiveCustomer(id, user.Jwt);
+    setArchivedList((prev) => prev.filter((c) => c.id !== id));
+    const moved = archivedList.find((c) => c.id === id);
+    if (moved) {
+      setActiveList((prev) => [{ ...moved, is_archived: false }, ...prev]);
+    }
+    toast({
+      status: "success",
+      description: "Customer successfully unarchived",
+    });
+  };
+
+  return (
+    <div className="flex flex-col">
+      <CustomerPage
+        searchTerm={search}
+        customers={activeList}
+        currentPage={currentPage}
+        totalPages={pages}
+        totalCount={activeList.length}
+        onArchiveCustomer={handleArchive}
+      />
+      <CustomerPage
+        title="Archived Customers"
+        isArchivedList
+        searchTerm={search}
+        customers={archivedList}
+        currentPage={archivedCurrentPage}
+        totalPages={archivedPages}
+        totalCount={archivedList.length}
+        onUnarchiveCustomer={handleUnarchive}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
- Changed customer page
- Changed customer info panel 
- Changed Customer page component 
- Created customers manager component
---

# 🧠 Reason for Changes

<!-- Explain why this change was necessary -->
- Changed customer page - The dashboard page now renders a CustomersManager component instead of two separate CustomerPage components so that active and archived lists stay synchronized without reloading the page

- Changed customer info panel - CustomerInfoPanel updates its local state and shows toast messages when a customer is archived or unarchived, and passes the updated data back through its callback for immediate UI refresh

- Changed Customer page component - CustomerPage keeps a local customerList and updates it when customers are edited, archived, or unarchived, closing the drawer and displaying success toasts so the table reflects changes instantly

- Created customers manager component - The new CustomersManager maintains separate active and archived lists, moving customers between them and providing toast feedback whenever archive status changes to keep both tables in sync
---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [X] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [ ] Backend APIs tested via Postman
- [X] No console errors (Frontend)
- [ ] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---



# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
- https://trello.com/c/GwWg1cSF/253-fix-customer-page-revalidations
---


