### PR TITLE
[Chore] Updated Practice page so CRUD operations are shown on the page after they are made 

### DIFF
--- a/app/(dashboard)/manage/practices/page.tsx
+++ b/app/(dashboard)/manage/practices/page.tsx
@@ -3,7 +3,7 @@
 // Admin-only page that lists all practices and provides
 // a drawer interface for creating, editing and deleting practices.
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import PracticesPage from "@/components/practices/PracticesPage";
 import RoleProtected from "@/components/RoleProtected";
 import { getAllPractices } from "@/services/practices";
@@ -15,25 +15,26 @@ export default function PracticesPageContainer() {
   const [practices, setPractices] = useState<Practice[]>([]);
   const [loading, setLoading] = useState(true);
 
-  useEffect(() => {
-    const fetchData = async () => {
-      try {
-        const res = await getAllPractices();
-        setPractices(res);
-      } catch (err) {
-        console.error("Failed to fetch practices", err);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchData();
+  const refreshPractices = useCallback(async () => {
+    try {
+      const res = await getAllPractices();
+      setPractices(res);
+    } catch (err) {
+      console.error("Failed to fetch practices", err);
+    } finally {
+      setLoading(false);
+    }
   }, []);
+
+  useEffect(() => {
+    setLoading(true);
+    refreshPractices();
+  }, [refreshPractices]);
 
   const content = loading ? (
     <PageSkeleton />
   ) : (
-    <PracticesPage practices={practices} />
+    <PracticesPage practices={practices} onRefresh={refreshPractices} />
   );
 
   return (

--- a/components/practices/AddPracticeForm.tsx
+++ b/components/practices/AddPracticeForm.tsx
@@ -23,7 +23,13 @@ import { Team } from "@/types/team";
 import { Court } from "@/types/court";
 import { revalidatePractices } from "@/actions/serverActions";
 
-export default function AddPracticeForm({ onClose }: { onClose?: () => void }) {
+export default function AddPracticeForm({
+  onClose,
+  onAdded,
+}: {
+  onClose?: () => void;
+  onAdded?: () => void;
+}) {
   const { data, updateField, resetData } = useFormData({
     team_id: "",
     location_id: "",
@@ -145,6 +151,7 @@ export default function AddPracticeForm({ onClose }: { onClose?: () => void }) {
       });
       resetData();
       await revalidatePractices();
+      if (onAdded) onAdded();
       if (onClose) onClose();
     } else {
       toast({

--- a/components/practices/PracticeInfoPanel.tsx
+++ b/components/practices/PracticeInfoPanel.tsx
@@ -23,9 +23,13 @@ import { Court } from "@/types/court";
 export default function PracticeInfoPanel({
   practice,
   onClose,
+  onUpdated,
+  onDeleted,
 }: {
   practice: Practice;
   onClose?: () => void;
+  onUpdated?: () => void;
+  onDeleted?: () => void;
 }) {
   const { data, updateField } = useFormData({
     team_id: practice.team_id || "",
@@ -102,6 +106,7 @@ export default function PracticeInfoPanel({
         description: "Practice updated successfully",
       });
       await revalidatePractices();
+      if (onUpdated) onUpdated();
     } else {
       toast({
         status: "error",
@@ -121,6 +126,7 @@ export default function PracticeInfoPanel({
         description: "Practice deleted successfully",
       });
       await revalidatePractices();
+      if (onDeleted) onDeleted();
       if (onClose) onClose();
     } else {
       toast({

--- a/components/practices/PracticesPage.tsx
+++ b/components/practices/PracticesPage.tsx
@@ -24,8 +24,10 @@ import {
 
 export default function PracticesPage({
   practices,
+  onRefresh,
 }: {
   practices: Practice[];
+  onRefresh: () => void;
 }) {
   const [selectedPractice, setSelectedPractice] = useState<Practice | null>(
     null
@@ -129,11 +131,16 @@ export default function PracticesPage({
           {drawerContent === "details" && selectedPractice && (
             <PracticeInfoPanel
               practice={selectedPractice}
+              onUpdated={onRefresh}
+              onDeleted={onRefresh}
               onClose={() => setDrawerOpen(false)}
             />
           )}
           {drawerContent === "add" && (
-            <AddPracticeForm onClose={() => setDrawerOpen(false)} />
+            <AddPracticeForm
+              onClose={() => setDrawerOpen(false)}
+              onAdded={onRefresh}
+            />
           )}
         </div>
       </RightDrawer>


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
- Changed Practice Page
- Changed Add practice form
- Changed practice info panel
- Changed Practice page component 

---

# 🧠 Reason for Changes

<!-- Explain why this change was necessary -->
- Changed Practice Page - The page container now defines a refreshPractices callback that fetches updated practices on mount and provides this function to the child page component, enabling data to reload automatically without a manual refresh

- Changed Add practice form - AddPracticeForm accepts a new optional onAdded callback and calls it after creating a practice so the parent page can immediately refresh the list

- Changed practice info panel - PracticeInfoPanel now receives onUpdated and onDeleted callbacks and triggers them whenever a practice is saved or deleted, prompting the parent to refresh its data

- Changed Practice page component - The PracticesPage component itself accepts an onRefresh function and passes it to both PracticeInfoPanel and AddPracticeForm so edits or additions update the displayed practices right away
---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [X] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [ ] Backend APIs tested via Postman
- [X] No console errors (Frontend)
- [ ] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---



# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
- https://trello.com/c/xaDM5t1U/254-fix-practice-page-revalidations

---

