### PR TITLE
[Chore] Added Alert styling on confirms for archiving and unarchiving customers 

### DIFF
--- a/components/customers/CustomerInfoPanel.tsx
+++ b/components/customers/CustomerInfoPanel.tsx
@@ -6,6 +6,17 @@ import { Customer } from "@/types/customer";
 import DetailsTab from "./infoTabs/CustomerDetails";
 import { Button } from "@/components/ui/button";
 import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import {
   TrashIcon,
   UserCircle,
   CreditCard,
@@ -44,6 +55,7 @@ export default function CustomerInfoPanel({
   const [isLoading, setIsLoading] = useState(false);
   const [currentCustomer, setCurrentCustomer] = useState<Customer>(customer);
   const [membershipPlans, setMembershipPlans] = useState<MembershipPlan[]>([]);
+  const [archiveDialogOpen, setArchiveDialogOpen] = useState(false);
 
   const { toast } = useToast();
   const { user } = useUser();
@@ -298,14 +310,39 @@ export default function CustomerInfoPanel({
           </p>
 
           <div className="flex items-center gap-3">
-            <Button
-              variant="outline"
-              onClick={handleArchiveToggle}
-              className="border-destructive text-destructive hover:bg-destructive/10"
-            >
-              <TrashIcon className="h-4 w-4 mr-2" />
-              {currentCustomer.is_archived ? "Unarchive" : "Archive"}
-            </Button>
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <Button
+                  variant="outline"
+                  className="border-destructive text-destructive hover:bg-destructive/10"
+                >
+                  <TrashIcon className="h-4 w-4 mr-2" />
+                  {currentCustomer.is_archived ? "Unarchive" : "Archive"}
+                </Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>
+                    {currentCustomer.is_archived
+                      ? "Confirm Unarchive"
+                      : "Confirm Archive"}
+                  </AlertDialogTitle>
+                  <AlertDialogDescription>
+                    {currentCustomer.is_archived
+                      ? "Are you sure you want to unarchive this customer?"
+                      : "Are you sure you want to archive this customer?"}
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Cancel</AlertDialogCancel>
+                  <AlertDialogAction onClick={handleArchiveToggle}>
+                    {currentCustomer.is_archived
+                      ? "Confirm Unarchive"
+                      : "Confirm Archive"}
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
           </div>
         </div>
       </div>

--- a/components/customers/CustomerTable.tsx
+++ b/components/customers/CustomerTable.tsx
@@ -31,6 +31,18 @@ import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { ArrowUpDown, MoreHorizontal, FolderSearch } from "lucide-react";
 
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+
 // Dropdown menu components
 import {
   DropdownMenu,
@@ -164,20 +176,45 @@ export const columns: ColumnDef<Customer>[] = [
                 <span>Edit</span>
               </DropdownMenuItem>
               <DropdownMenuSeparator />
-              <DropdownMenuItem
-                className="px-3 py-2 hover:bg-destructive/10 cursor-pointer text-destructive"
-                onClick={() => {
-                  const handler = (table.options.meta as any)
-                    ?.onArchiveCustomer;
-                  handler?.(customer.id);
-                }}
-              >
-                <span>
-                  {(table.options.meta as any)?.isArchivedList
-                    ? "Unarchive"
-                    : "Archive"}
-                </span>
-              </DropdownMenuItem>
+              <AlertDialog>
+                <AlertDialogTrigger asChild>
+                  <DropdownMenuItem className="px-3 py-2 hover:bg-destructive/10 cursor-pointer text-destructive">
+                    <span>
+                      {(table.options.meta as any)?.isArchivedList
+                        ? "Unarchive"
+                        : "Archive"}
+                    </span>
+                  </DropdownMenuItem>
+                </AlertDialogTrigger>
+                <AlertDialogContent>
+                  <AlertDialogHeader>
+                    <AlertDialogTitle>
+                      {(table.options.meta as any)?.isArchivedList
+                        ? "Confirm Unarchive"
+                        : "Confirm Archive"}
+                    </AlertDialogTitle>
+                    <AlertDialogDescription>
+                      {(table.options.meta as any)?.isArchivedList
+                        ? "Are you sure you want to unarchive this customer?"
+                        : "Are you sure you want to archive this customer?"}
+                    </AlertDialogDescription>
+                  </AlertDialogHeader>
+                  <AlertDialogFooter>
+                    <AlertDialogCancel>Cancel</AlertDialogCancel>
+                    <AlertDialogAction
+                      onClick={() => {
+                        const handler = (table.options.meta as any)
+                          ?.onArchiveCustomer;
+                        handler?.(customer.id);
+                      }}
+                    >
+                      {(table.options.meta as any)?.isArchivedList
+                        ? "Confirm Unarchive"
+                        : "Confirm Archive"}
+                    </AlertDialogAction>
+                  </AlertDialogFooter>
+                </AlertDialogContent>
+              </AlertDialog>
             </DropdownMenuContent>
           </DropdownMenu>
         </div>


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
- Changed customer info panel
- Changed customer table 
---

# 🧠 Reason for Changes

<!-- Explain why this change was necessary -->
- Changed customer info panel / Changed customer table - Added an AlertDialog around the archive button so the user must confirm before archiving or unarchiving a customer, preventing accidental actions 
---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [X] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [ ] Backend APIs tested via Postman
- [X] No console errors (Frontend)
- [ ] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---


# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
- https://trello.com/c/FMxxgrOE/257-add-styles-to-customers-confirm-archive-unarchive
---


