### PR TITLE
[Chore] Added alert components to match styling of deletes across the app on the locations components 

### DIFF
--- a/components/locations/LocationInfoPanel.tsx
+++ b/components/locations/LocationInfoPanel.tsx
@@ -7,9 +7,14 @@ import DetailsTab from "./infoTabs/Details";
 import { BuildingIcon } from "lucide-react";
 import SchedulesTab from "./infoTabs/Schedule";
 
-export default function FacilityInfoPanel({ facility }: { facility: Location }) {
-
-  const [activeTab, setActiveTab] = useState("details")
+export default function FacilityInfoPanel({
+  facility,
+  onDelete,
+}: {
+  facility: Location;
+  onDelete?: () => void;
+}) {
+  const [activeTab, setActiveTab] = useState("details");
 
   return (
     <div className="space-y-6">
@@ -34,9 +39,7 @@ export default function FacilityInfoPanel({ facility }: { facility: Location }) 
         </div>
 
         <TabsContent value="details" className="pt-4">
-          <DetailsTab
-            details={facility}
-          />
+          <DetailsTab details={facility} onDelete={onDelete} />
         </TabsContent>
 
         <TabsContent value="schedule" className="pt-4">

--- a/components/locations/LocationPage.tsx
+++ b/components/locations/LocationPage.tsx
@@ -53,6 +53,11 @@ export default function FacilitiesPage({
     setDrawerOpen(true);
   };
 
+  const handleDrawerClose = () => {
+    setDrawerOpen(false);
+    setSelectedFacility(null);
+  };
+
   return (
     <div className="flex-1 space-y-4 p-6 pt-6">
       <div className="flex items-center justify-between">
@@ -125,7 +130,7 @@ export default function FacilitiesPage({
       />
       <RightDrawer
         drawerOpen={drawerOpen}
-        handleDrawerClose={() => setDrawerOpen(false)}
+        handleDrawerClose={handleDrawerClose}
         drawerWidth={drawerContent === "details" ? "w-[75%]" : "w-[25%]"}
       >
         <div className="p-4">
@@ -135,7 +140,10 @@ export default function FacilitiesPage({
               : "Add New Facility"}
           </h2>
           {drawerContent === "details" && selectedFacility && (
-            <FacilityInfoPanel facility={selectedFacility} />
+            <FacilityInfoPanel
+              facility={selectedFacility}
+              onDelete={handleDrawerClose}
+            />
           )}
           {drawerContent === "add" && <AddFacilityForm />}
         </div>


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
- Changed location info panel
- Changed location page
- Changed info tabs details 

---

# 🧠 Reason for Changes

<!-- Explain why this change was necessary -->
- Location Info Panel - The panel now accepts an optional onDelete callback and forwards it to the DetailsTab so the parent drawer can be closed after a location is removed

- Location Page - A new handleDrawerClose function closes the drawer and clears the selected facility, and this function is supplied both to RightDrawer and to FacilityInfoPanel so that deleting a location or manually closing the drawer leaves the page in a clean state

- Details tab - The Details tab imports the shared AlertDialog components, supports an optional onDelete prop, and replaces the browser confirm dialog with this alert so deletion is confirmed once and triggers the provided callback after a successful API call
---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [X] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [ ] Backend APIs tested via Postman
- [X] No console errors (Frontend)
- [ ] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---



# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
- https://trello.com/c/7NmlDSFf/259-add-styles-to-locations-confirm-delete
---



