### PR TITLE
[Chore] Added styles to Courts confirm delete, Info panel now auto closes after deleting a court 

### DIFF
--- a/components/courts/CourtPage.tsx
+++ b/components/courts/CourtPage.tsx
@@ -55,6 +55,12 @@ export default function CourtPage({ courts }: { courts: Court[] }) {
     setDrawerOpen(true); // Open the drawer
   };
 
+  const handleCloseDrawer = () => {
+    setDrawerOpen(false);
+    setSelectedCourt(null);
+    setDrawerContent(null);
+  };
+
   return (
     <div className="flex-1 space-y-4 p-6 pt-6">
       {/* Header with title and Add Court button */}
@@ -127,7 +133,7 @@ export default function CourtPage({ courts }: { courts: Court[] }) {
       {/* Right-side drawer for details or add form */}
       <RightDrawer
         drawerOpen={drawerOpen} // Control open state
-        handleDrawerClose={() => setDrawerOpen(false)} // Close handler
+        handleDrawerClose={handleCloseDrawer} // Close handler
         drawerWidth={drawerContent === "details" ? "w-[75%]" : "w-[25%]"} // Width based on content
       >
         <div className="p-4">
@@ -136,7 +142,7 @@ export default function CourtPage({ courts }: { courts: Court[] }) {
           </h2>
           {/* Conditionally render details panel or add form */}
           {drawerContent === "details" && selectedCourt && (
-            <CourtInfoPanel court={selectedCourt} />
+            <CourtInfoPanel court={selectedCourt} onClose={handleCloseDrawer} />
           )}
           {drawerContent === "add" && <AddCourtForm />}
         </div>


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
- Changed court info panel
- Changed court page component 
---

# 🧠 Reason for Changes

<!-- Explain why this change was necessary -->
- Changed court info panel - The CourtInfoPanel introduces an optional onClose prop and replaces the browser confirm with an AlertDialog so the drawer can automatically close after deletion using a shared confirmation UI

- Changed court page component - CourtPage adds a handleCloseDrawer function that hides the drawer and clears its state, passing this callback to both the drawer and the CourtInfoPanel so the panel disappears once a court is removed
---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [X] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [ ] Backend APIs tested via Postman
- [X] No console errors (Frontend)
- [ ] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---



# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
- https://trello.com/c/UDIKBMEA/260-add-styles-to-courts-confirm-delete

---

