### PR TITLE
[Chore] Added styling on confirm delete for memberships 

### DIFF
--- a/components/memberships/MembershipInfoPanel.tsx
+++ b/components/memberships/MembershipInfoPanel.tsx
@@ -5,13 +5,15 @@ import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { Membership } from "@/types/membership";
 import DetailsTab from "./infoTabs/Details";
 import PlansTab from "./infoTabs/plans/Plans";
-import {
-  CreditCard,
-  ShoppingBag,
-} from "lucide-react";
+import { CreditCard, ShoppingBag } from "lucide-react";
 
-export default function MembershipInfoPanel({ membership }: { membership: Membership }) {
-
+export default function MembershipInfoPanel({
+  membership,
+  onClose,
+}: {
+  membership: Membership;
+  onClose: () => void;
+}) {
   const [activeTab, setActiveTab] = useState("details");
 
   return (
@@ -37,25 +39,21 @@ export default function MembershipInfoPanel({ membership }: { membership: Member
         </div>
 
         <TabsContent value="details" className="pt-4">
-          <DetailsTab
-            details={membership}
-          />
+          <DetailsTab details={membership} onClose={onClose} />
           <div className="max-w-5xl mx-auto px-4 flex justify-between items-center pt-5">
             <p className="text-sm text-muted-foreground">
-              Last updated: {membership.updated_at ? new Date(membership.updated_at).toLocaleString() : "Never"}
+              Last updated:{" "}
+              {membership.updated_at
+                ? new Date(membership.updated_at).toLocaleString()
+                : "Never"}
             </p>
-
-           
           </div>
         </TabsContent>
 
         <TabsContent value="plans" className="pt-4">
-          <PlansTab
-            membershipId={membership.id}
-          />
+          <PlansTab membershipId={membership.id} />
         </TabsContent>
       </Tabs>
-
     </div>
   );
 }

--- a/components/memberships/MembershipPage.tsx
+++ b/components/memberships/MembershipPage.tsx
@@ -140,7 +140,10 @@ export default function MembershipsPage({
               : "Add Membership"}
           </h2>
           {drawerContent === "details" && selectedMembership && (
-            <MembershipInfoPanel membership={selectedMembership} />
+            <MembershipInfoPanel
+              membership={selectedMembership}
+              onClose={() => setDrawerOpen(false)}
+            />
           )}
           {drawerContent === "add" && <AddMembershipForm />}
         </div>

--- a/components/memberships/infoTabs/Details.tsx
+++ b/components/memberships/infoTabs/Details.tsx
@@ -5,6 +5,17 @@ import { MembershipRequestDto } from "@/app/api/Api";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
 import { useUser } from "@/contexts/UserContext";
 import { toast } from "@/hooks/use-toast";
 import { deleteMembership, updateMembership } from "@/services/membership";
@@ -12,7 +23,13 @@ import { Membership } from "@/types/membership";
 import { PencilIcon, SaveIcon, TrashIcon } from "lucide-react";
 import { useForm } from "react-hook-form";
 
-export default function DetailsTab({ details }: { details: Membership }) {
+export default function DetailsTab({
+  details,
+  onClose,
+}: {
+  details: Membership;
+  onClose: () => void;
+}) {
   const { user } = useUser();
 
   const { register, getValues } = useForm({
@@ -46,21 +63,16 @@ export default function DetailsTab({ details }: { details: Membership }) {
   };
 
   const handleDeleteMembership = async () => {
-    if (
-      confirm(
-        "Are you sure you want to delete this membership? This action cannot be undone."
-      )
-    ) {
-      try {
-        await deleteMembership(details.id, user?.Jwt!);
-        toast({
-          status: "success",
-          description: "Membership deleted successfully",
-        });
-        await revalidateMemberships();
-      } catch (error) {
-        toast({ status: "error", description: "Error deleting membership" });
-      }
+    try {
+      await deleteMembership(details.id, user?.Jwt!);
+      toast({
+        status: "success",
+        description: "Membership deleted successfully",
+      });
+      await revalidateMemberships();
+      onClose();
+    } catch (error) {
+      toast({ status: "error", description: "Error deleting membership" });
     }
   };
 
@@ -94,21 +106,39 @@ export default function DetailsTab({ details }: { details: Membership }) {
 
       <div className="flex items-center justify-end gap-3 mt-4">
         <Button
-          variant="destructive"
-          onClick={handleDeleteMembership}
-          className="bg-red-600 hover:bg-red-700"
-        >
-          <TrashIcon className="h-4 w-4 mr-2" />
-          Delete Membership
-        </Button>
-
-        <Button
           onClick={handleSaveInfo}
           className="bg-green-600 hover:bg-green-700"
         >
           <SaveIcon className="h-4 w-4 mr-2" />
           Save Changes
         </Button>
+
+        <AlertDialog>
+          <AlertDialogTrigger asChild>
+            <Button
+              variant="destructive"
+              className="bg-red-600 hover:bg-red-700"
+            >
+              <TrashIcon className="h-4 w-4 mr-2" />
+              Delete Membership
+            </Button>
+          </AlertDialogTrigger>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Confirm Deletion</AlertDialogTitle>
+              <AlertDialogDescription>
+                Are you sure you want to delete this membership? This action
+                cannot be undone.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction onClick={handleDeleteMembership}>
+                Confirm Delete
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
       </div>
     </div>
   );


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
- Changed membership info panel 
- Changed membership page component 
- Changed membership info tab details 

---

# 🧠 Reason for Changes

<!-- Explain why this change was necessary -->
- Membership info panel: Added an onClose callback so the panel can hide immediately after a membership is deleted.

- Membership page component: Passed the drawer’s close handler down to the info panel to ensure the drawer closes automatically once a membership removal is confirmed.

- Membership info tab details: Wrapped the delete action in the shared AlertDialog and removed the browser confirm to provide a single, consistent confirmation flow with accurate toast notifications.
---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [X] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [ ] Backend APIs tested via Postman
- [X] No console errors (Frontend)
- [ ] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---



# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
- https://trello.com/c/MQT8ENii/261-add-styles-to-membership-confirm-delete

---



