### PR TITLE
[Chore] Added styles to confirm delete alert

### DIFF
--- a/components/staff/StaffForm.tsx
+++ b/components/staff/StaffForm.tsx
@@ -16,6 +16,17 @@ import { Switch } from "@/components/ui/switch";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { FileText, Trash, Save } from "lucide-react";
 import { useUser } from "@/contexts/UserContext";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
 import getValue from "@/configs/constants";
 import { useToast } from "@/hooks/use-toast";
 import { revalidateStaffs } from "@/actions/serverActions";
@@ -28,7 +39,13 @@ const ROLE_OPTIONS = Object.entries(StaffRoleEnum).map(([key, value]) => ({
   value,
 }));
 
-export default function StaffForm({ StaffData }: { StaffData?: User }) {
+export default function StaffForm({
+  StaffData,
+  onClose,
+}: {
+  StaffData?: User;
+  onClose?: () => void;
+}) {
   const [activeTab, setActiveTab] = useState("details");
   const [role, setRole] = useState(StaffData?.StaffInfo?.Role || "");
   const [isActive, setIsActive] = useState(
@@ -107,25 +124,20 @@ export default function StaffForm({ StaffData }: { StaffData?: User }) {
   };
 
   const DeleteStaff = async () => {
-    if (
-      confirm(
-        "Are you sure you want to delete this staff member? This action cannot be undone."
-      )
-    ) {
-      try {
-        await deleteStaff(StaffData?.ID!, jwt!);
-        toast({
-          status: "success",
-          description: "Staff member deleted successfully",
-        });
-        RefreshData();
-      } catch (err) {
-        toast({
-          status: "error",
-          description: "Error deleting staff",
-          variant: "destructive",
-        });
-      }
+    try {
+      await deleteStaff(StaffData?.ID!, jwt!);
+      toast({
+        status: "success",
+        description: "Staff member deleted successfully",
+      });
+      RefreshData();
+      onClose?.();
+    } catch (err) {
+      toast({
+        status: "error",
+        description: "Error deleting staff",
+        variant: "destructive",
+      });
     }
   };
 
@@ -239,14 +251,32 @@ export default function StaffForm({ StaffData }: { StaffData?: User }) {
               <Save className="h-4 w-4 mr-2" />
               Save Changes
             </Button>
-            <Button
-              variant="destructive"
-              className="bg-red-600 hover:bg-red-700"
-              onClick={(e) => DeleteStaff()}
-            >
-              <Trash className="h-4 w-4 mr-2" />
-              Delete
-            </Button>
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <Button
+                  variant="destructive"
+                  className="bg-red-600 hover:bg-red-700"
+                >
+                  <Trash className="h-4 w-4 mr-2" />
+                  Delete
+                </Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Confirm Deletion</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    Are you sure you want to delete this staff member? This
+                    action cannot be undone.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Cancel</AlertDialogCancel>
+                  <AlertDialogAction onClick={DeleteStaff}>
+                    Confirm Delete
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
           </div>
         </div>
       </div>

--- a/components/staff/StaffPage.tsx
+++ b/components/staff/StaffPage.tsx
@@ -140,9 +140,12 @@ export default function StaffPage({ staffs }: { staffs: User[] }) {
         >
           <div className="p-4">
             {isNewStaff ? (
-              <StaffForm />
+              <StaffForm onClose={handleDrawerClose} />
             ) : selectedStaff ? (
-              <StaffForm StaffData={selectedStaff} />
+              <StaffForm
+                StaffData={selectedStaff}
+                onClose={handleDrawerClose}
+              />
             ) : null}
           </div>
         </RightDrawer>


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
- Changed staff form
- Changed staff page component 

---

# 🧠 Reason for Changes

<!-- Explain why this change was necessary -->
- Changed staff form: To replace the native browser confirm with the event-style AlertDialog and ensure the drawer closes automatically after a staff member is deleted.

- Changed staff page component: To pass the drawer’s close handler into the form so deleting a staff member closes the info panel without additional user interaction.
---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [X] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [ ] Backend APIs tested via Postman
- [X] No console errors (Frontend)
- [ ] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---



# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
- https://trello.com/c/xEmVJYrP/263-add-styles-to-staff-confirm-delete

---



