### PR TITLE
[Chore] Added alert styling to confirm delete for teams

### DIFF
--- a/components/teams/TeamInfoPanel.tsx
+++ b/components/teams/TeamInfoPanel.tsx
@@ -7,6 +7,17 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { SaveIcon, TrashIcon } from "lucide-react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
 import RightDrawer from "@/components/reusable/RightDrawer";
 import RosterEditor from "./RosterEditor";
 import { useUser } from "@/contexts/UserContext";
@@ -58,9 +69,8 @@ export default function TeamInfoPanel({
     }
   };
 
-  // Prompt for confirmation and delete the team via API
+  // Delete the team via API
   const handleDelete = async () => {
-    if (!confirm("Are you sure you want to delete this team?")) return;
     try {
       const error = await deleteTeam(team.id, user?.Jwt!);
       if (error === null) {
@@ -135,13 +145,31 @@ export default function TeamInfoPanel({
           >
             <SaveIcon className="h-4 w-4 mr-2" /> Save Changes
           </Button>
-          <Button
-            variant="destructive"
-            className="bg-red-600 hover:bg-red-700"
-            onClick={handleDelete}
-          >
-            <TrashIcon className="h-4 w-4 mr-2" /> Delete
-          </Button>
+          <AlertDialog>
+            <AlertDialogTrigger asChild>
+              <Button
+                variant="destructive"
+                className="bg-red-600 hover:bg-red-700"
+              >
+                <TrashIcon className="h-4 w-4 mr-2" /> Delete
+              </Button>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Confirm Deletion</AlertDialogTitle>
+                <AlertDialogDescription>
+                  Are you sure you want to delete this team? This action cannot
+                  be undone.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                <AlertDialogAction onClick={handleDelete}>
+                  Confirm Delete
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
         </div>
       </div>
       <RightDrawer


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
- Changed team info panel

---

# 🧠 Reason for Changes

<!-- Explain why this change was necessary -->
- TeamInfoPanel was updated to use the shared AlertDialog instead of the native confirm prompt, ensuring consistent deletion confirmation without duplicate prompts or missing toast notifications.
---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [X] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [ ] Backend APIs tested via Postman
- [X] No console errors (Frontend)
- [ ] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---



# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
- https://trello.com/c/dZXbM1WL/264-add-styles-to-teams-confirm-delete

---



