### PR TITLE
[Chore] Added alert styling to confirm deletes for practices 

### DIFF
--- a/components/practices/PracticeInfoPanel.tsx
+++ b/components/practices/PracticeInfoPanel.tsx
@@ -6,6 +6,17 @@ import { useEffect, useState } from "react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { SaveIcon, TrashIcon } from "lucide-react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
 import { useUser } from "@/contexts/UserContext";
 import { useToast } from "@/hooks/use-toast";
 import { useFormData } from "@/hooks/form-data";
@@ -118,7 +129,6 @@ export default function PracticeInfoPanel({
 
   // Remove the practice entirely from the system
   const handleDelete = async () => {
-    if (!confirm("Are you sure you want to delete this practice?")) return;
     const error = await deletePractice(practice.id, user?.Jwt!);
     if (error === null) {
       toast({
@@ -237,13 +247,31 @@ export default function PracticeInfoPanel({
         >
           <SaveIcon className="h-4 w-4 mr-2" /> Save Changes
         </Button>
-        <Button
-          variant="destructive"
-          className="bg-red-600 hover:bg-red-700"
-          onClick={handleDelete}
-        >
-          <TrashIcon className="h-4 w-4 mr-2" /> Delete
-        </Button>
+        <AlertDialog>
+          <AlertDialogTrigger asChild>
+            <Button
+              variant="destructive"
+              className="bg-red-600 hover:bg-red-700"
+            >
+              <TrashIcon className="h-4 w-4 mr-2" /> Delete
+            </Button>
+          </AlertDialogTrigger>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Confirm Deletion</AlertDialogTitle>
+              <AlertDialogDescription>
+                Are you sure you want to delete this practice? This action
+                cannot be undone.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction onClick={handleDelete}>
+                Confirm Delete
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
       </div>
     </div>
   );


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
- Changed practice info panel 

---

# 🧠 Reason for Changes

<!-- Explain why this change was necessary -->
- We needed this change to replace the inconsistent browser confirm with a unified ShadCN alert dialog for deleting practices, ensuring a consistent and single confirmation flow across the app.
---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [X] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [ ] Backend APIs tested via Postman
- [X] No console errors (Frontend)
- [ ] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---



# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
- https://trello.com/c/RYNusv9h/265-add-styles-to-practice-confirm-delete

---



