### PR TITLE
[Chore] Added alert styling when deleting a system

### DIFF
--- a/components/Playground/SystemInfoPanel.tsx
+++ b/components/Playground/SystemInfoPanel.tsx
@@ -11,6 +11,17 @@ import {
 } from "@/services/playground";
 import { revalidatePlayground } from "@/actions/serverActions";
 import { PlaygroundSystem } from "@/types/playground";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
 
 export default function SystemInfoPanel({
   system,
@@ -46,7 +57,6 @@ export default function SystemInfoPanel({
   };
 
   const handleDelete = async () => {
-    if (!confirm("Delete this system?")) return;
     const error = await deletePlaygroundSystem(system.id, user?.Jwt!);
     if (error) {
       toast({
@@ -82,13 +92,31 @@ export default function SystemInfoPanel({
         >
           <SaveIcon className="h-4 w-4 mr-2" /> Save Changes
         </Button>
-        <Button
-          variant="destructive"
-          className="bg-red-600 hover:bg-red-700"
-          onClick={handleDelete}
-        >
-          <TrashIcon className="h-4 w-4 mr-2" /> Delete
-        </Button>
+        <AlertDialog>
+          <AlertDialogTrigger asChild>
+            <Button
+              variant="destructive"
+              className="bg-red-600 hover:bg-red-700"
+            >
+              <TrashIcon className="h-4 w-4 mr-2" /> Delete
+            </Button>
+          </AlertDialogTrigger>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Confirm Deletion</AlertDialogTitle>
+              <AlertDialogDescription>
+                Are you sure you want to delete this system? This action cannot
+                be undone.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction onClick={handleDelete}>
+                Confirm Delete
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
       </div>
     </div>
   );


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
- Changed system info panel 

---

# 🧠 Reason for Changes

<!-- Explain why this change was necessary -->
- The SystemInfoPanel was updated to reuse the alert dialog so system deletions show the same confirmation UI and avoid duplicate browser prompts, ensuring consistent toasts and a single alert flow.
---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [X] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [ ] Backend APIs tested via Postman
- [X] No console errors (Frontend)
- [ ] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---



# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
- https://trello.com/c/2OcrbiP8/266-add-styles-to-systems-confirm-delete

---


