### PR TITLE
[Bugfix] Multi day events will now show up and display across all days they are scheduled on 

### DIFF
--- a/components/calendar/body/month/calendar-body-month.tsx
+++ b/components/calendar/body/month/calendar-body-month.tsx
@@ -107,10 +107,11 @@ export default function CalendarBodyMonth() {
                   <div className="flex flex-col gap-1 mt-1">
                     {dayEvents.slice(0, 3).map((event) => (
                       <CalendarEvent
-                        key={event.id}
+                        key={`${event.id}-${format(day, "yyyy-MM-dd")}`}
                         event={event}
                         className="relative h-auto"
                         month
+                        currentDate={day}
                       />
                     ))}
                     {dayEvents.length > 3 && (

--- a/components/calendar/event/calendar-event.tsx
+++ b/components/calendar/event/calendar-event.tsx
@@ -146,7 +146,9 @@ export default function CalendarEvent({
               ease: "easeOut",
             },
           }}
-          layoutId={`event-${animationKey}-${month ? "month" : "day"}`}
+          layoutId={`event-${animationKey}-${
+            month ? format(currentDate ?? event.start_at, "yyyy-MM-dd") : "day"
+          }`}
         >
           <motion.div
             className={cn(


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
- Changed calendar event component
- Changed calendar body month component


---

# 🧠 Reason for Changes

<!-- Explain why this change was necessary -->
- Changed calendar event component – Introduced day-aware layout keys so Framer Motion treats each day of a multi-day event as distinct, preventing layout collisions.

- Changed calendar body month component – Passed a day-specific key and current date to each event instance so multi-day events render across every day they span.
---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [X] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [ ] Backend APIs tested via Postman
- [X] No console errors (Frontend)
- [ ] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---



# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
- https://trello.com/c/IlLrUI7f/275-fix-multi-day-events-so-they-always-show-up

---

