### PR TITLE
[Chore] Changed roster styles to fix bug

### DIFF
--- a/components/teams/TeamInfoPanel.tsx
+++ b/components/teams/TeamInfoPanel.tsx
@@ -128,7 +128,7 @@ export default function TeamInfoPanel({
               {team.roster.length > 0 ? (
                 <ul className="divide-y rounded-md border">
                   {team.roster.map((member, index) => (
-                    <li key={member.id} className="p-2 even:bg-gray-50">
+                    <li key={member.id} className="p-2 even:bg-secondary">
                       {index + 1}. {member.name}
                     </li>
                   ))}


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
- Changed even members on the roster so the background is our secondary color variable instead of a gray-50

---

# 🧠 Reason for Changes

<!-- Explain why this change was necessary -->
- Made this change so going from light mode to dark mode the background on the roster is visible and readable on both modes and will stay consistent 
---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [X] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [ ] Backend APIs tested via Postman
- [X] No console errors (Frontend)
- [ ] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---



# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
- https://trello.com/c/ZYfCBA7m/276-style-rosters-to-fix-dark-mode

---



