### PR TITLE
[Chore] Added a confirm delete with styled alerts for the membership plans

### DIFF
--- a/components/memberships/infoTabs/plans/Plans.tsx
+++ b/components/memberships/infoTabs/plans/Plans.tsx
@@ -1,6 +1,17 @@
 import { useEffect, useState } from "react";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
 import { useToast } from "@/hooks/use-toast";
 import { useUser } from "@/contexts/UserContext";
 import getValue from "@/configs/constants";
@@ -324,16 +335,36 @@ export default function PlansTab({ membershipId }: { membershipId: string }) {
                     {" "}
                     Save{" "}
                   </div>
-                  <div
-                    className="p-1 pl-5 pr-5 bg-red-700 hover:bg-red-900 rounded cursor-pointer"
-                    onClick={(e) => {
-                      e.stopPropagation;
-                      DeletePlan(plan.id);
-                    }}
-                  >
-                    {" "}
-                    Delete{" "}
-                  </div>
+                  <AlertDialog>
+                    <AlertDialogTrigger asChild>
+                      <div
+                        className="p-1 pl-5 pr-5 bg-red-700 hover:bg-red-900 rounded cursor-pointer"
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        {" "}
+                        Delete{" "}
+                      </div>
+                    </AlertDialogTrigger>
+                    <AlertDialogContent>
+                      <AlertDialogHeader>
+                        <AlertDialogTitle>Confirm Delete</AlertDialogTitle>
+                        <AlertDialogDescription>
+                          Are you sure you want to delete this plan? This action
+                          cannot be undone.
+                        </AlertDialogDescription>
+                      </AlertDialogHeader>
+                      <AlertDialogFooter>
+                        <AlertDialogCancel>Cancel</AlertDialogCancel>
+                        <AlertDialogAction
+                          onClick={() => {
+                            DeletePlan(plan.id);
+                          }}
+                        >
+                          Confirm Delete
+                        </AlertDialogAction>
+                      </AlertDialogFooter>
+                    </AlertDialogContent>
+                  </AlertDialog>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
- Changed Membership Plans styling

---

# 🧠 Reason for Changes

<!-- Explain why this change was necessary -->
- The change ensures users must confirm before deleting membership plans, preventing accidental removals and maintaining consistent alert dialog styling across the app.
---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [X] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [ ] Backend APIs tested via Postman
- [X] No console errors (Frontend)
- [ ] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---



# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
- https://trello.com/c/30tPBnPX/262-add-confirm-and-styles-to-membership-plans-delete

---



