### PR TITLE
[Chore] Added alerts for confirming a cancelation of a Barbershop Appointment 

### DIFF
--- a/components/Barbershop/AppointmentInfoPanel.tsx
+++ b/components/Barbershop/AppointmentInfoPanel.tsx
@@ -10,6 +10,17 @@ import { useUser } from "@/contexts/UserContext";
 import { deleteHaircutEvent } from "@/services/haircuts";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { Calendar, ClipboardList, Clock, User } from "lucide-react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
 
 interface AppointmentInfoPanelProps {
   appointment: HaircutEventEventResponseDto;
@@ -21,7 +32,7 @@ export default function AppointmentInfoPanel({
   onAppointmentUpdated,
 }: AppointmentInfoPanelProps) {
   const [tabValue, setTabValue] = useState("details");
-  const [isDeleting, setIsDeleting] = useState(false);
+  const [isCancelling, setIsCancelling] = useState(false);
   const { toast } = useToast();
   const { user } = useUser();
 
@@ -42,35 +53,31 @@ export default function AppointmentInfoPanel({
     return `${diffMinutes} minutes`;
   };
 
-  // Handle delete appointment
-  const handleDeleteAppointment = async () => {
+  // Handle cancel appointment
+  const handleCancelAppointment = async () => {
     if (!appointment.id || !user?.Jwt) {
       toast({
         status: "error",
-        description: "Unable to delete appointment: Missing information",
+        description: "Unable to cancel appointment: Missing information",
       });
       return;
     }
 
-    if (!confirm("Are you sure you want to delete this appointment?")) {
-      return;
-    }
-
     try {
-      setIsDeleting(true);
+      setIsCancelling(true);
       await deleteHaircutEvent(appointment.id, user.Jwt);
       toast({
         status: "success",
-        description: "Appointment deleted successfully",
+        description: "Appointment canceled successfully",
       });
       if (onAppointmentUpdated) {
         onAppointmentUpdated();
       }
     } catch (error) {
       console.error("Error deleting appointment:", error);
-      toast({ status: "error", description: "Failed to delete appointment" });
+      toast({ status: "error", description: "Failed to cancel appointment" });
     } finally {
-      setIsDeleting(false);
+      setIsCancelling(false);
     }
   };
 
@@ -162,14 +169,31 @@ export default function AppointmentInfoPanel({
           </p>
 
           <div className="flex items-center gap-3">
-            <Button
-              variant="destructive"
-              onClick={handleDeleteAppointment}
-              disabled={isDeleting}
-              className="bg-red-600 hover:bg-red-700"
-            >
-              {isDeleting ? "Deleting..." : "Delete Appointment"}
-            </Button>
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <Button
+                  variant="destructive"
+                  disabled={isCancelling}
+                  className="bg-red-600 hover:bg-red-700"
+                >
+                  {isCancelling ? "Canceling..." : "Cancel Appointment"}
+                </Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Confirm Cancellation</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    Are you sure you want to cancel this appointment?
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Keep Appointment</AlertDialogCancel>
+                  <AlertDialogAction onClick={handleCancelAppointment}>
+                    Confirm Cancel
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
           </div>
         </div>
       </div>

--- a/components/Barbershop/Appointments.tsx
+++ b/components/Barbershop/Appointments.tsx
@@ -296,12 +296,12 @@ export default function AppointmentsPage() {
     setDrawerOpen(true);
   };
 
-  // Handle appointment deletion
+  // Handle appointment cancellation
   const handleDeleteAppointment = async (id: string) => {
     if (!user?.Jwt) {
       toast({
         status: "error",
-        description: "You must be logged in to delete appointments",
+        description: "You must be logged in to cancel appointments",
       });
       return;
     }
@@ -310,7 +310,7 @@ export default function AppointmentsPage() {
       await deleteHaircutEvent(id, user.Jwt);
       toast({
         status: "success",
-        description: "Appointment deleted successfully",
+        description: "Appointment canceled successfully",
       });
 
       // Remove from state
@@ -323,7 +323,7 @@ export default function AppointmentsPage() {
       }
     } catch (error) {
       console.error("Error deleting appointment:", error);
-      toast({ status: "error", description: "Failed to delete appointment" });
+      toast({ status: "error", description: "Failed to cancel appointment" });
     }
   };
 

--- a/components/Barbershop/BarberTable.tsx
+++ b/components/Barbershop/BarberTable.tsx
@@ -19,6 +19,17 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
 import { HaircutEventEventResponseDto } from "@/app/api/Api";
 import { format } from "date-fns";
 import { fromZonedISOString } from "@/lib/utils";
@@ -227,21 +238,40 @@ export default function BarberTable({
                           </DropdownMenuItem>
                           <DropdownMenuSeparator />
                           {onDeleteAppointment && (
-                            <DropdownMenuItem
-                              className="px-3 py-2 hover:bg-destructive/10 cursor-pointer text-destructive"
-                              onClick={() => {
-                                if (
-                                  confirm(
-                                    "Are you sure you want to delete this appointment?"
-                                  ) &&
-                                  appointment.id
-                                ) {
-                                  onDeleteAppointment(appointment.id);
-                                }
-                              }}
-                            >
-                              <span>Delete</span>
-                            </DropdownMenuItem>
+                            <AlertDialog>
+                              <AlertDialogTrigger asChild>
+                                <DropdownMenuItem
+                                  className="px-3 py-2 hover:bg-destructive/10 cursor-pointer text-destructive"
+                                  onSelect={(e) => e.preventDefault()}
+                                >
+                                  <span>Cancel Appointment</span>
+                                </DropdownMenuItem>
+                              </AlertDialogTrigger>
+                              <AlertDialogContent>
+                                <AlertDialogHeader>
+                                  <AlertDialogTitle>
+                                    Confirm Cancellation
+                                  </AlertDialogTitle>
+                                  <AlertDialogDescription>
+                                    Are you sure you want to cancel this
+                                    appointment?
+                                  </AlertDialogDescription>
+                                </AlertDialogHeader>
+                                <AlertDialogFooter>
+                                  <AlertDialogCancel>
+                                    Keep Appointment
+                                  </AlertDialogCancel>
+                                  <AlertDialogAction
+                                    onClick={() =>
+                                      appointment.id &&
+                                      onDeleteAppointment(appointment.id)
+                                    }
+                                  >
+                                    Confirm Cancel
+                                  </AlertDialogAction>
+                                </AlertDialogFooter>
+                              </AlertDialogContent>
+                            </AlertDialog>
                           )}
                         </DropdownMenuContent>
                       </DropdownMenu>


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
- Changed appointment info panel 
- Changed appointments 
- Changed barber table

---

# 🧠 Reason for Changes

<!-- Explain why this change was necessary -->
- Changed appointment info panel – replaced the default browser confirm with a styled alert dialog so users cancel appointments through a consistent, branded UI.
- Changed appointments – updated list view actions to use “Cancel Appointment” phrasing and the new cancellation dialog to align with the rest of the app’s toast-driven workflow.
- Changed barber table – rewired table actions to trigger the same cancellation dialog and toast messages, ensuring unified behavior across all barbershop scheduling components.
---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [X] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [ ] Backend APIs tested via Postman
- [X] No console errors (Frontend)
- [ ] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---



# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
- https://trello.com/c/tO71f27X/268-add-styles-to-barbershop-confirm-cancel

---



