### PR TITLE
[Feature] Updated Coach role view, can no longer see dashboard page or link related to it 

### DIFF
--- a/app/(dashboard)/page.tsx
+++ b/app/(dashboard)/page.tsx
@@ -17,6 +17,9 @@ import { format, isSameDay } from "date-fns";
 import { getEvents } from "@/services/events";
 import { getAllGames } from "@/services/games";
 import { getAllPractices } from "@/services/practices";
+import { useRouter } from "next/navigation";
+import { useUser } from "@/contexts/UserContext";
+import { StaffRoleEnum } from "@/types/user";
 import {
   Users,
   Calendar,
@@ -79,6 +82,14 @@ const recentActivity = [
 
 export default function DashboardPage() {
   const [schedule, setSchedule] = useState<ScheduleItem[]>([]);
+  const { user } = useUser();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (user?.Role === StaffRoleEnum.COACH) {
+      router.replace("/calendar");
+    }
+  }, [user, router]);
 
   useEffect(() => {
     const loadSchedule = async () => {

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -23,6 +23,7 @@ import { useToast } from "@/hooks/use-toast";
 import { Loader2 } from "lucide-react";
 import { loginWithFirebaseToken } from "@/services/auth";
 import { useUser } from "@/contexts/UserContext";
+import { StaffRoleEnum } from "@/types/user";
 
 export default function Login() {
   const [email, setEmail] = useState("");
@@ -70,7 +71,7 @@ export default function Login() {
         setUser(user);
 
         toast({ status: "success", description: "Successfully logged in!" });
-        router.push("/");
+        router.push(user.Role === StaffRoleEnum.COACH ? "/calendar" : "/");
       } else {
         toast({
           status: "error",
@@ -111,7 +112,7 @@ export default function Login() {
           status: "success",
           description: "Successfully logged in with Google!",
         });
-        router.push("/");
+        router.push(user.Role === StaffRoleEnum.COACH ? "/calendar" : "/");
       } else {
         toast({
           status: "error",

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -101,39 +101,53 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
           ]
         : [];
 
-  const navMain = [
-    {
-      title: "Dashboard",
-      url: "/",
-      icon: <HomeIcon width={20} height={15} />,
-      isActive: true,
-      items: [
-        // Everyone with access can see Calendar
-        {
-          title: "Calendar",
-          url: "/calendar",
-          icon: <Calendar width={15} height={15} />,
-        },
-      ],
-    },
-    // Only include Manage section when there are items to show
-    ...(manageItems.length
+  const navMain =
+    role === StaffRoleEnum.COACH
       ? [
           {
-            title: "Manage",
-            icon: <Wrench width={15} height={15} />,
-            isActive: true,
-            items: manageItems,
+            title: "Calendar",
+            url: "/calendar",
+            icon: <Calendar width={15} height={15} />,
           },
+          // Only include Manage section when there are items to show
+          ...(manageItems.length
+            ? [
+                {
+                  title: "Manage",
+                  icon: <Wrench width={15} height={15} />,
+                  isActive: true,
+                  items: manageItems,
+                },
+              ]
+            : []),
         ]
-      : []),
-  ];
-
-  const navUserProps = {
-    email: user?.Email || "",
-    name: user?.Name || "",
-    avatar: "/avatars/shadcn.jpg",
-  };
+      : [
+          {
+            title: "Dashboard",
+            url: "/",
+            icon: <HomeIcon width={20} height={15} />,
+            isActive: true,
+            items: [
+              // Everyone with access can see Calendar
+              {
+                title: "Calendar",
+                url: "/calendar",
+                icon: <Calendar width={15} height={15} />,
+              },
+            ],
+          },
+          // Only include Manage section when there are items to show
+          ...(manageItems.length
+            ? [
+                {
+                  title: "Manage",
+                  icon: <Wrench width={15} height={15} />,
+                  isActive: true,
+                  items: manageItems,
+                },
+              ]
+            : []),
+        ];
 
   return (
     <Sidebar collapsible="icon" {...props}>

--- a/contexts/UserContext.tsx
+++ b/contexts/UserContext.tsx
@@ -2,7 +2,7 @@
 
 import { createContext, useContext, useState, useEffect } from "react";
 import { useRouter, usePathname } from "next/navigation";
-import { LoggedInUser, User } from "@/types/user";
+import { LoggedInUser, StaffRoleEnum } from "@/types/user";
 import { onIdTokenChanged } from "firebase/auth";
 import { auth } from "@/configs/firebase";
 import { loginWithFirebaseToken } from "@/services/auth";
@@ -30,8 +30,8 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     if (user !== null) {
-      if (pathname === '/login') {
-        router.push('/');
+      if (pathname === "/login") {
+        router.push(user.Role === StaffRoleEnum.COACH ? "/calendar" : "/");
         return;
       }
       setIsLoading(false); // Not loading once we have a user
@@ -59,7 +59,9 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
           // Update user context
           setUser(backendUser);
           if (pathname === "/login") {
-            router.push("/");
+            router.push(
+              backendUser.Role === StaffRoleEnum.COACH ? "/calendar" : "/"
+            );
           }
         } else {
           console.error("Backend authentication failed, user is null");
@@ -78,7 +80,7 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
     // Update context state
     setUser(null);
     // Optional: Force a hard refresh for a clean state
-    window.location.href = '/login';
+    window.location.href = "/login";
   };
 
   return (


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
- Changed dashboard page 
- Changed login page
- Changed side bar component 
- Changed user context 

---

# 🧠 Reason for Changes

<!-- Explain why this change was necessary -->
- Dashboard page: Added a client-side guard so coaches navigating to the root dashboard route are immediately redirected to the calendar, preventing access to dashboard content.
- Login page: Updated post-authentication logic to send coach users directly to the calendar instead of the dashboard upon successful login.
- Sidebar component: Removed the dashboard entry and surfaced the calendar as the primary navigation link for coaches to reflect their default landing page.
- User context: Adjusted role-based routing in the user context to ensure coach sessions default to the calendar and never point to the dashboard.
---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [X] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [ ] Backend APIs tested via Postman
- [X] No console errors (Frontend)
- [ ] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---



# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
- https://trello.com/c/2cFsZtev/280-take-dashboard-out-for-coaches-view

---


