### PR TITLE
[Bugfix] Using Parse event data from website to fix 6 hour time difference on AP

### DIFF
--- a/lib/dates.ts
+++ b/lib/dates.ts
@@ -9,16 +9,86 @@
  * console.log(formattedDate); // Output: "March 7, 2025, 6:07 PM MST"
  */
 function formatDate(isoString: string): string {
-    const date = new Date(isoString);
-    return new Intl.DateTimeFormat("en-US", {
-        year: "numeric",
-        month: "long",
-        day: "numeric",
-        hour: "2-digit",
-        minute: "2-digit",
-        second: "2-digit",
-        timeZoneName: "short",
-    }).format(date);
+  const date = new Date(isoString);
+  return new Intl.DateTimeFormat("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    timeZoneName: "short",
+  }).format(date);
 }
 
-export { formatDate };
+/**
+ * Parses various date string formats used by the backend into a Date object.
+ *
+ * This handles duplicated timezone offsets and several common formats such as:
+ * - "YYYY-MM-DD HH:MM:SS -0700 MST"
+ * - "YYYY-MM-DD HH:MM:SS -0600"
+ * - ISO strings
+ * - Generic date strings
+ *
+ * @param dateString Date string from the backend
+ * @returns Parsed Date or null if parsing fails
+ */
+function parseEventDate(dateString: string): Date | null {
+  if (!dateString || dateString.trim() === "") {
+    console.warn("Empty or null date string provided");
+    return null;
+  }
+
+  let cleanedString = dateString.trim();
+
+  // Fix duplicate timezone offsets like "-0600 -0600"
+  const duplicateTimezonePattern = /(-0[67]00)\s+(-0[67]00)$/;
+  if (duplicateTimezonePattern.test(cleanedString)) {
+    cleanedString = cleanedString.replace(duplicateTimezonePattern, "$1");
+  }
+
+  let parsedDate: Date;
+
+  if (
+    cleanedString.includes("T") &&
+    (cleanedString.includes("Z") || cleanedString.includes("+"))
+  ) {
+    // Already in ISO format
+    parsedDate = new Date(cleanedString);
+  } else if (
+    cleanedString.includes(" MST") ||
+    (cleanedString.includes(" -0700") && !cleanedString.includes("T"))
+  ) {
+    // "YYYY-MM-DD HH:MM:SS -0700 MST"
+    const isoString = cleanedString
+      .replace(" MST", "")
+      .replace(" -0700", "-07:00")
+      .replace(" ", "T");
+    parsedDate = new Date(isoString);
+  } else if (
+    cleanedString.includes(" MDT") ||
+    (cleanedString.includes(" -0600") && !cleanedString.includes("T"))
+  ) {
+    // "YYYY-MM-DD HH:MM:SS -0600"
+    const isoString = cleanedString
+      .replace(" MDT", "")
+      .replace(" -0600", "-06:00")
+      .replace(" ", "T");
+    parsedDate = new Date(isoString);
+  } else if (/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/.test(cleanedString)) {
+    // Generic "YYYY-MM-DD HH:MM:SS"
+    const isoString = cleanedString.replace(" ", "T");
+    parsedDate = new Date(isoString);
+  } else {
+    parsedDate = new Date(cleanedString);
+  }
+
+  if (isNaN(parsedDate.getTime())) {
+    console.error("Failed to parse date:", dateString);
+    return null;
+  }
+
+  return parsedDate;
+}
+
+export { formatDate, parseEventDate };

--- a/services/events.ts
+++ b/services/events.ts
@@ -11,6 +11,7 @@ import {
   EventCreateRequest,
   EventRecurrenceCreateRequest,
 } from "@/types/events";
+import { parseEventDate } from "@/lib/dates";
 
 export async function getEventsByMonth(
   month: string
@@ -334,8 +335,8 @@ export async function getSchedulesOfProgram(
       const sch: EventSchedule = {
         id: schedule.id!,
         day: schedule.day!,
-        recurrence_start_at: new Date(schedule.recurrence_start_at!),
-        recurrence_end_at: new Date(schedule.recurrence_end_at!),
+        recurrence_start_at: parseEventDate(schedule.recurrence_start_at!)!,
+        recurrence_end_at: parseEventDate(schedule.recurrence_end_at!)!,
         event_start_at: schedule.session_start_at!,
         event_end_at: schedule.session_end_at!,
         location: {
@@ -391,8 +392,8 @@ export async function getEvent(id: string): Promise<Event> {
 
     const evt: Event = {
       id: event.id!,
-      start_at: new Date(event.start_at!),
-      end_at: new Date(event.end_at!),
+      start_at: parseEventDate(event.start_at!)!,
+      end_at: parseEventDate(event.end_at!)!,
       location: {
         id: event.location!.id!,
         name: event.location!.name!,


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
- Changed events service
- Changed dates lib

---

# 🧠 Reason for Changes

<!-- Explain why this change was necessary -->
- Changed events service: The event service now uses parseEventDate when mapping schedule and event times, ensuring backend strings like "YYYY-MM-DD HH:MM:SS -0600" are converted into accurate Date objects instead of shifting by six hours

- Changed dates lib: A new parseEventDate utility sanitizes backend date strings by removing duplicate timezone offsets and translating several format variants into standard ISO strings, preventing misinterpretation of America/Edmonton timestamps as UTC
---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [X] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [ ] Backend APIs tested via Postman
- [X] No console errors (Frontend)
- [ ] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---



# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
- https://trello.com/c/p8lfSQXB/273-fix-reoccurring-events

---



