### PR TITLE
[Bugfix] Added the parse event date when inputting dates to fix the time zone bug

### DIFF
--- a/components/calendar/event/AddEventForm.tsx
+++ b/components/calendar/event/AddEventForm.tsx
@@ -24,7 +24,7 @@ import { revalidateEvents } from "@/actions/serverActions";
 import { useCalendarContext } from "../calendar-context";
 import { CalendarEvent } from "@/types/calendar";
 import { colorOptions } from "@/components/calendar/calendar-tailwind-classes";
-import { toZonedISOString } from "@/lib/utils";
+import { formatEventDate } from "@/lib/dates";
 
 function getColorFromProgramType(programType?: string): string {
   switch (programType) {
@@ -121,8 +121,8 @@ export default function AddEventForm({ onClose }: { onClose?: () => void }) {
         team_id: data.team_id || undefined,
         location_id: data.location_id,
         court_id: data.court_id ? data.court_id : null,
-        start_at: toZonedISOString(new Date(data.start_at)),
-        end_at: toZonedISOString(new Date(data.end_at)),
+        start_at: formatEventDate(new Date(data.start_at)),
+        end_at: formatEventDate(new Date(data.end_at)),
         capacity: data.capacity ? Number(data.capacity) : undefined,
       };
 
@@ -157,8 +157,8 @@ export default function AddEventForm({ onClose }: { onClose?: () => void }) {
         team_id: data.team_id || undefined,
         location_id: data.location_id,
         court_id: data.court_id ? data.court_id : null,
-        recurrence_start_at: toZonedISOString(startDate),
-        recurrence_end_at: toZonedISOString(endDate),
+        recurrence_start_at: formatEventDate(startDate),
+        recurrence_end_at: formatEventDate(endDate),
         event_start_at: formatTime(data.event_start_at),
         event_end_at: formatTime(data.event_end_at),
         day: data.day,

--- a/components/calendar/event/EditEventForm.tsx
+++ b/components/calendar/event/EditEventForm.tsx
@@ -20,7 +20,7 @@ import { revalidateEvents } from "@/actions/serverActions";
 import { useCalendarContext } from "../calendar-context";
 import { CalendarEvent } from "@/types/calendar";
 import { colorOptions } from "@/components/calendar/calendar-tailwind-classes";
-import { toZonedISOString } from "@/lib/utils";
+import { formatEventDate } from "@/lib/dates";
 
 function getColorFromProgramType(programType?: string): string {
   switch (programType) {
@@ -95,8 +95,8 @@ export default function EditEventForm({ onClose }: { onClose?: () => void }) {
           (selectedEvent as any).court?.id ||
           (selectedEvent as any).court_id ||
           "",
-        start_at: toZonedISOString(selectedEvent.start_at).slice(0, 16),
-        end_at: toZonedISOString(selectedEvent.end_at).slice(0, 16),
+        start_at: formatEventDate(selectedEvent.start_at).slice(0, 16),
+        end_at: formatEventDate(selectedEvent.end_at).slice(0, 16),
       });
     }
   }, [selectedEvent]);
@@ -125,8 +125,8 @@ export default function EditEventForm({ onClose }: { onClose?: () => void }) {
       team_id: data.team_id || undefined,
       location_id: data.location_id,
       court_id: data.court_id ? data.court_id : null,
-      start_at: toZonedISOString(new Date(data.start_at)),
-      end_at: toZonedISOString(new Date(data.end_at)),
+      start_at: formatEventDate(new Date(data.start_at)),
+      end_at: formatEventDate(new Date(data.end_at)),
     };
 
     const error = await updateEvent(selectedEvent.id, eventData, user?.Jwt!);


### PR DESCRIPTION

# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
- Changed dates lib
- Changed add event form
- Changed edit event form
---

# 🧠 Reason for Changes

<!-- Explain why this change was necessary -->
- Changed dates lib - Introduced formatEventDate to emit ISO strings with the America/Edmonton offset so saved event times keep their intended hour

- Changed add event form - The form now formats start and recurrence dates via formatEventDate before submission so the backend stores the correct local times

- Changed edit event form - Edited events submit start and end times using formatEventDate, preventing timezone shifts after updates
---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [X] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [ ] Backend APIs tested via Postman
- [X] No console errors (Frontend)
- [ ] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)



---

# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
- https://trello.com/c/p8lfSQXB/273-fix-reoccurring-events

---

