### PR TITLE
[Bugfix] Edit time now shows correct time instead of six hours different 

### DIFF
--- a/components/calendar/event/EditEventForm.tsx
+++ b/components/calendar/event/EditEventForm.tsx
@@ -20,7 +20,7 @@ import { revalidateEvents } from "@/actions/serverActions";
 import { useCalendarContext } from "../calendar-context";
 import { CalendarEvent } from "@/types/calendar";
 import { colorOptions } from "@/components/calendar/calendar-tailwind-classes";
-import { toZonedISOString } from "@/lib/utils";
+import { toZonedISOString, toLocalISOString } from "@/lib/utils";
 
 function getColorFromProgramType(programType?: string): string {
   switch (programType) {
@@ -95,8 +95,8 @@ export default function EditEventForm({ onClose }: { onClose?: () => void }) {
           (selectedEvent as any).court?.id ||
           (selectedEvent as any).court_id ||
           "",
-        start_at: toZonedISOString(selectedEvent.start_at).slice(0, 16),
-        end_at: toZonedISOString(selectedEvent.end_at).slice(0, 16),
+        start_at: toLocalISOString(selectedEvent.start_at).slice(0, 16),
+        end_at: toLocalISOString(selectedEvent.end_at).slice(0, 16),
       });
     }
   }, [selectedEvent]);

--- a/components/games/GameInfoPanel.tsx
+++ b/components/games/GameInfoPanel.tsx
@@ -14,7 +14,11 @@ import { revalidateGames } from "@/actions/serverActions";
 import { Game } from "@/types/games";
 import { Location } from "@/types/location";
 import { Team } from "@/types/team";
-import { toZonedISOString, fromZonedISOString } from "@/lib/utils";
+import {
+  toZonedISOString,
+  fromZonedISOString,
+  toLocalISOString,
+} from "@/lib/utils";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -38,8 +42,11 @@ export default function GameInfoPanel({
     home_team_id: game.home_team_id,
     away_team_id: game.away_team_id,
     location_id: game.location_id,
-    start_time: fromZonedISOString(game.start_time).toISOString().slice(0, 16),
-    end_time: fromZonedISOString(game.end_time).toISOString().slice(0, 16),
+    start_time: toLocalISOString(fromZonedISOString(game.start_time)).slice(
+      0,
+      16
+    ),
+    end_time: toLocalISOString(fromZonedISOString(game.end_time)).slice(0, 16),
     status: game.status as "scheduled" | "completed" | "canceled",
   });
   const { user } = useUser();

--- a/components/practices/PracticeInfoPanel.tsx
+++ b/components/practices/PracticeInfoPanel.tsx
@@ -30,7 +30,11 @@ import { Practice } from "@/types/practice";
 import { Location } from "@/types/location";
 import { Team } from "@/types/team";
 import { Court } from "@/types/court";
-import { toZonedISOString, fromZonedISOString } from "@/lib/utils";
+import {
+  toZonedISOString,
+  fromZonedISOString,
+  toLocalISOString,
+} from "@/lib/utils";
 
 export default function PracticeInfoPanel({
   practice,
@@ -47,8 +51,11 @@ export default function PracticeInfoPanel({
     team_id: practice.team_id || "",
     location_id: practice.location_id || "",
     court_id: practice.court_id || "",
-    start_at: fromZonedISOString(practice.start_at).toISOString().slice(0, 16),
-    end_at: fromZonedISOString(practice.end_at).toISOString().slice(0, 16),
+    start_at: toLocalISOString(fromZonedISOString(practice.start_at)).slice(
+      0,
+      16
+    ),
+    end_at: toLocalISOString(fromZonedISOString(practice.end_at)).slice(0, 16),
     capacity: practice.capacity,
     status: practice.status as "scheduled" | "completed" | "canceled",
   });

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -58,6 +58,20 @@ export function fromZonedISOString(isoString: string): Date {
 }
 
 /**
+ * Convert a Date to an ISO string adjusted to the local timezone.
+ *
+ * Useful for pre-filling `datetime-local` input values without shifting
+ * the visible time.
+ *
+ * @param date - The date to convert.
+ * @returns ISO string representing the same wall-clock time.
+ */
+export function toLocalISOString(date: Date): string {
+  const offsetMs = date.getTimezoneOffset() * 60 * 1000;
+  return new Date(date.getTime() - offsetMs).toISOString();
+}
+
+/**
  * Converts a given date to a UTC date string with the time set to 00:00:00.
  *
  * This function ensures that the date remains the same across time zones, but any time component


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
- Added to utils lib file
- Changed edit event form
- Changed Game info panel
- Changed practice info panel 
---

# 🧠 Reason for Changes

<!-- Explain why this change was necessary -->
- Added to utils lib file: Introduced timezone-aware helpers like toLocalISOString and neutral offset handling to convert stored timestamps without shifting local times.

- Changed edit event form: Replaced direct ISO formatting with the new local-time helper so events open in the editor at the correct hour instead of appearing six hours off.

- Changed Game info panel: Updated all game-related datetime fields to use the local formatting helper, preventing inadvertent timezone shifts when displaying or editing game times.

- Changed practice info panel: Adopted the same local-time utilities for practice events, ensuring practice times remain accurate during viewing and updates.

---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [X] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [ ] Backend APIs tested via Postman
- [X] No console errors (Frontend)
- [ ] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---



# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
- https://trello.com/c/p8lfSQXB/273-fix-reoccurring-events

---


