### PR TITLE
[Chore] Added auto closing panel when adding a new membership 

### DIFF
--- a/components/memberships/AddForm.tsx
+++ b/components/memberships/AddForm.tsx
@@ -5,13 +5,17 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { toast } from "sonner";
-import getValue from "@/configs/constants";
 import { useUser } from "@/contexts/UserContext";
 import { createMembership } from "@/services/membership";
 import { MembershipRequestDto } from "@/app/api/Api";
 import { revalidateMemberships } from "@/actions/serverActions";
+import { on } from "events";
 
-export default function AddMembershipForm() {
+export default function AddMembershipForm({
+  onSuccess,
+}: {
+  onSuccess?: () => void;
+}) {
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
 
@@ -38,8 +42,7 @@ export default function AddMembershipForm() {
       await revalidateMemberships();
 
       toast.success("Membership created successfully");
-
-
+      onSuccess?.();
     } catch (error) {
       console.error("Error during API request:", error);
       toast.error("Failed to add membership. Please try again.");
@@ -72,7 +75,9 @@ export default function AddMembershipForm() {
         </div>
       </div>
 
-      <Button onClick={handleAddMembership} className="w-full">Add Membership</Button>
+      <Button onClick={handleAddMembership} className="w-full">
+        Add Membership
+      </Button>
     </div>
   );
 }

--- a/components/memberships/MembershipPage.tsx
+++ b/components/memberships/MembershipPage.tsx
@@ -6,10 +6,7 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import MembershipInfoPanel from "./MembershipInfoPanel";
 import AddMembershipForm from "./AddForm";
-import { toast } from "sonner";
 import RightDrawer from "@/components/reusable/RightDrawer";
-import { useUser } from "@/contexts/UserContext";
-import { revalidateMemberships } from "@/actions/serverActions";
 import MembershipTable from "./table/MembershipTable";
 import {
   DropdownMenu,
@@ -36,8 +33,6 @@ export default function MembershipsPage({
     useState<Membership | null>(null);
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({});
   const [searchQuery, setSearchQuery] = useState("");
-
-  const { user } = useUser();
 
   // Filter memberships based on search query
   const filteredMemberships = searchQuery
@@ -145,7 +140,9 @@ export default function MembershipsPage({
               onClose={() => setDrawerOpen(false)}
             />
           )}
-          {drawerContent === "add" && <AddMembershipForm />}
+          {drawerContent === "add" && (
+            <AddMembershipForm onSuccess={() => setDrawerOpen(false)} />
+          )}
         </div>
       </RightDrawer>
     </div>


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
- Changed membership add form
- Changed membership page 
---

# 🧠 Reason for Changes

<!-- Explain why this change was necessary -->
- Changed membership add form – The form now accepts and triggers an optional onSuccess callback, allowing the parent page to close the drawer after a membership is successfully created

- Changed membership page – The page passes a drawer-closing callback to the add form so the side panel automatically hides once a new membership is added
---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [X] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [ ] Backend APIs tested via Postman
- [X] No console errors (Frontend)
- [ ] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---

# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
- https://trello.com/c/2V8PuUMc/284-add-membership-panel-close-auto

---


