### PR TITLE
[Chore] Added a auto closer after adding a new court

### DIFF
--- a/components/courts/AddCourtForm.tsx
+++ b/components/courts/AddCourtForm.tsx
@@ -19,7 +19,11 @@ import { CourtRequestDto } from "@/app/api/Api"; // DTO type for court creation 
 import { revalidateCourts } from "@/actions/serverActions"; // Action to revalidate court data on server
 import { Location } from "@/types/location"; // Type definition for a location
 
-export default function AddCourtForm() {
+export default function AddCourtForm({
+  onCourtAdded,
+}: {
+  onCourtAdded?: () => void;
+}) {
   // Initialize form data state with default values
   const { data, updateField, resetData } = useFormData({
     name: "",
@@ -55,10 +59,11 @@ export default function AddCourtForm() {
     // Call API to create the court
     const error = await createCourt(courtData, user?.Jwt!);
     if (error === null) {
-      // On success, show success toast, reset form, and revalidate cache
+      // On success, show success toast, reset form, and revalidate cache and close panel
       toast({ status: "success", description: "Court created successfully" });
       resetData();
       await revalidateCourts();
+      onCourtAdded?.();
     } else {
       // On failure, show error toast with message
       toast({

--- a/components/courts/CourtPage.tsx
+++ b/components/courts/CourtPage.tsx
@@ -144,7 +144,9 @@ export default function CourtPage({ courts }: { courts: Court[] }) {
           {drawerContent === "details" && selectedCourt && (
             <CourtInfoPanel court={selectedCourt} onClose={handleCloseDrawer} />
           )}
-          {drawerContent === "add" && <AddCourtForm />}
+          {drawerContent === "add" && (
+            <AddCourtForm onCourtAdded={handleCloseDrawer} />
+          )}
         </div>
       </RightDrawer>
     </div>


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
- Changed add court form
- Changed court page 

---

# 🧠 Reason for Changes

<!-- Explain why this change was necessary -->
- Changed add court form: Introduced an optional post-add callback so the drawer could close automatically after a successful court creation.

- Changed court page: Passed the drawer’s close handler into the form so the side panel shuts when a new court is added.
---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [X] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [ ] Backend APIs tested via Postman
- [X] No console errors (Frontend)
- [ ] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---


# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
- https://trello.com/c/AbxsE5YZ/290-create-court-auto-close-side-panel

---



