### PR TITLE
[Chore] Update booked_by to follow backend and properly display the name 

### DIFF
--- a/components/practices/PracticeInfoPanel.tsx
+++ b/components/practices/PracticeInfoPanel.tsx
@@ -157,9 +157,9 @@ export default function PracticeInfoPanel({
 
   return (
     <div className="space-y-6">
-      {practice.booked_by && (
+      {practice.booked_by_name && (
         <p className="text-sm text-muted-foreground">
-          Booked By: {practice.booked_by}
+          Booked By: {practice.booked_by_name}
         </p>
       )}
       <div className="space-y-4">

--- a/components/practices/table/columns.tsx
+++ b/components/practices/table/columns.tsx
@@ -48,10 +48,10 @@ const columns: ColumnDef<Practice>[] = [
     size: 220,
   },
   {
-    id: "booked_by",
-    accessorKey: "booked_by",
+    id: "booked_by_name",
+    accessorKey: "booked_by_name",
     header: "Booked By",
-    cell: ({ row }) => row.getValue("booked_by") || "-",
+    cell: ({ row }) => row.getValue("booked_by_name"),
     minSize: 150,
     size: 200,
   },

--- a/services/practices.ts
+++ b/services/practices.ts
@@ -34,9 +34,9 @@ export async function getAllPractices(): Promise<Practice[]> {
     location_name: p.location_name ?? "",
     team_id: p.team_id,
     team_name: p.team_name,
-    booked_by: p.created_by
+    booked_by_name: p.created_by
       ? `${p.created_by.first_name} ${p.created_by.last_name}`
-      : (p.booked_by ?? ""),
+      : (p.booked_by_name ?? ""),
     start_at: p.start_time,
     end_at: p.end_time,
     capacity: 0,

--- a/types/practice.ts
+++ b/types/practice.ts
@@ -8,7 +8,7 @@ export interface Practice {
   location_name: string;
   team_id?: string;
   team_name?: string;
-  booked_by?: string;
+  booked_by_name?: string;
   start_at: string;
   end_at: string;
   capacity: number;


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
- Changed practice info panel
- Changed practice table column 
- Changed practice service 
- Changed practice types 


---

# 🧠 Reason for Changes

<!-- Explain why this change was necessary -->
- Changed practice info panel: Ensures the practice detail view displays the actual name of the person who booked the practice rather than a numeric user ID.

- Changed practice table column: Allows practice lists to show the booker’s name directly in the table for clearer, more user-friendly information.

- Changed practice service: Updates the data mapping layer so API responses correctly expose booked_by_name to the client instead of the outdated booked_by ID.

- Changed practice types: Aligns TypeScript definitions with the new booked_by_name field so the codebase accurately models the booking data structure.
---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [X] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [ ] Backend APIs tested via Postman
- [X] No console errors (Frontend)
- [ ] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---


# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
- https://trello.com/c/ayvKxTBR/294-change-bookedby-to-bookedbyname

---


