### PR TITLE
[Chore] Added auto closers after updating anything on the AP

### DIFF
--- a/components/courts/CourtInfoPanel.tsx
+++ b/components/courts/CourtInfoPanel.tsx
@@ -67,6 +67,7 @@ export default function CourtInfoPanel({
       // On success, notify and revalidate ISR
       toast({ status: "success", description: "Court updated successfully" });
       await revalidateCourts();
+      onClose?.();
     } else {
       // On failure, show error message
       toast({ status: "error", description: `Error saving changes: ${error}` });

--- a/components/customers/CustomerInfoPanel.tsx
+++ b/components/customers/CustomerInfoPanel.tsx
@@ -44,12 +44,14 @@ interface CustomerInfoPanelProps {
   customer: Customer;
   onCustomerUpdated?: (updated: Partial<Customer>) => void;
   onCustomerArchived?: (id: string) => Promise<void> | void;
+  onClose?: () => void;
 }
 
 export default function CustomerInfoPanel({
   customer,
   onCustomerUpdated,
   onCustomerArchived,
+  onClose,
 }: CustomerInfoPanelProps) {
   const [tabValue, setTabValue] = useState("details");
   const [isLoading, setIsLoading] = useState(false);
@@ -202,6 +204,7 @@ export default function CustomerInfoPanel({
                 description: "Customer information updated",
               });
             }}
+            onClose={onClose}
           />
         </TabsContent>
 

--- a/components/customers/CustomerPage.tsx
+++ b/components/customers/CustomerPage.tsx
@@ -358,6 +358,7 @@ export default function CustomersPage({
                   ? onUnarchiveCustomer || handleUnarchive
                   : onArchiveCustomer || handleArchive
               }
+              onClose={() => setDrawerOpen(false)}
             />
           )}
           {drawerContent === "add" && (

--- a/components/customers/infoTabs/CustomerDetails.tsx
+++ b/components/customers/infoTabs/CustomerDetails.tsx
@@ -17,9 +17,11 @@ import { SaveIcon } from "lucide-react";
 export default function DetailsTab({
   customer,
   onCustomerUpdated,
+  onClose,
 }: {
   customer: Customer; // Customer data passed in
   onCustomerUpdated?: (updated: Partial<Customer>) => void; // Callback after update
+  onClose?: () => void;
 }) {
   const { toast } = useToast(); // Toast utility
   const { user } = useUser(); // Current user (for JWT)
@@ -145,6 +147,7 @@ export default function DetailsTab({
             email: formData.email,
             phone: formattedPhone,
           });
+        onClose?.();
       } else {
         // Show API error
         toast({ status: "error", description: error });

--- a/components/games/GameInfoPanel.tsx
+++ b/components/games/GameInfoPanel.tsx
@@ -117,6 +117,7 @@ export default function GameInfoPanel({
       toast({ status: "success", description: "Game updated successfully" });
       await revalidateGames();
       if (refreshGames) await refreshGames();
+      onClose?.();
     } else {
       toast({
         status: "error",

--- a/components/locations/LocationInfoPanel.tsx
+++ b/components/locations/LocationInfoPanel.tsx
@@ -10,9 +10,11 @@ import SchedulesTab from "./infoTabs/Schedule";
 export default function FacilityInfoPanel({
   facility,
   onDelete,
+  onClose,
 }: {
   facility: Location;
   onDelete?: () => void;
+  onClose?: () => void;
 }) {
   const [activeTab, setActiveTab] = useState("details");
 
@@ -39,7 +41,11 @@ export default function FacilityInfoPanel({
         </div>
 
         <TabsContent value="details" className="pt-4">
-          <DetailsTab details={facility} onDelete={onDelete} />
+          <DetailsTab
+            details={facility}
+            onDelete={onDelete}
+            onClose={onClose}
+          />
         </TabsContent>
 
         <TabsContent value="schedule" className="pt-4">

--- a/components/locations/LocationPage.tsx
+++ b/components/locations/LocationPage.tsx
@@ -143,6 +143,7 @@ export default function FacilitiesPage({
             <FacilityInfoPanel
               facility={selectedFacility}
               onDelete={handleDrawerClose}
+              onClose={handleDrawerClose}
             />
           )}
           {drawerContent === "add" && (

--- a/components/locations/infoTabs/Details.tsx
+++ b/components/locations/infoTabs/Details.tsx
@@ -25,9 +25,11 @@ import { useForm } from "react-hook-form";
 export default function DetailsTab({
   details,
   onDelete,
+  onClose,
 }: {
   details: Location;
   onDelete?: () => void;
+  onClose?: () => void;
 }) {
   const { register, getValues } = useForm({
     defaultValues: {
@@ -53,6 +55,7 @@ export default function DetailsTab({
           description: "Location updated successfully",
         });
         await revalidateLocations();
+        onClose?.();
       } else {
         toast({
           status: "error",

--- a/components/practices/PracticeInfoPanel.tsx
+++ b/components/practices/PracticeInfoPanel.tsx
@@ -126,6 +126,7 @@ export default function PracticeInfoPanel({
       });
       await revalidatePractices();
       if (onUpdated) onUpdated();
+      onClose?.();
     } else {
       toast({
         status: "error",

--- a/components/programs/ProgramInfoPanel.tsx
+++ b/components/programs/ProgramInfoPanel.tsx
@@ -91,6 +91,7 @@ export default function ProgramInfoPanel({
           description: "Program updated successfully",
         });
         await revalidatePrograms();
+        onClose?.();
       } else {
         toast({
           status: "error",

--- a/components/staff/StaffForm.tsx
+++ b/components/staff/StaffForm.tsx
@@ -106,6 +106,7 @@ export default function StaffForm({
           description: "Staff member updated successfully",
         });
         RefreshData();
+        onClose?.();
       } else {
         toast({
           status: "error",

--- a/components/teams/TeamInfoPanel.tsx
+++ b/components/teams/TeamInfoPanel.tsx
@@ -53,6 +53,7 @@ export default function TeamInfoPanel({
       if (error === null) {
         toast({ status: "success", description: "Team updated successfully" });
         await revalidateTeams();
+        onClose?.();
       } else {
         toast({
           status: "error",


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
- Added auto closers to Locations, Courts, Memberships, Staff, Teams, Games, Practices, Customers, Archived Customers and Programs 
---

# 🧠 Reason for Changes

<!-- Explain why this change was necessary -->
- The changes were necessary to improve user experience: previously, after updating entities like programs or courts, the info drawer remained open, leaving the interface in an inconsistent state. By invoking each panel’s onClose callback after a successful save, the drawer closes automatically, revealing the updated list view and ensuring the UI reflects the new data immediately
---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [X] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [ ] Backend APIs tested via Postman
- [X] No console errors (Frontend)
- [ ] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---



# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
- https://trello.com/c/b1I5bn0D/302-auto-close-after-updating

---



