### PR TITLE
[Chore] Fixed Booked By to show who booked it after updating it 

### DIFF
--- a/app/(dashboard)/manage/practices/page.tsx
+++ b/app/(dashboard)/manage/practices/page.tsx
@@ -28,6 +28,7 @@ export default function PracticesPageContainer() {
         location_name: p.location_name ?? "",
         team_id: p.team_id,
         team_name: p.team_name,
+        booked_by: p.booked_by,
         booked_by_name: p.booked_by_name ?? "",
         start_at: p.start_time,
         end_at: p.end_time ?? "",

--- a/components/practices/PracticeInfoPanel.tsx
+++ b/components/practices/PracticeInfoPanel.tsx
@@ -116,6 +116,7 @@ export default function PracticeInfoPanel({
       start_time: toZonedISOString(new Date(data.start_at)),
       end_time: toZonedISOString(new Date(data.end_at)),
       status: data.status,
+      booked_by: practice.booked_by,
     };
 
     const error = await updatePractice(practice.id, practiceData, user?.Jwt!);

--- a/services/practices.ts
+++ b/services/practices.ts
@@ -34,6 +34,7 @@ export async function getAllPractices(): Promise<Practice[]> {
     location_name: p.location_name ?? "",
     team_id: p.team_id,
     team_name: p.team_name,
+    booked_by: p.created_by ? p.created_by.id : p.booked_by,
     booked_by_name: p.created_by
       ? `${p.created_by.first_name} ${p.created_by.last_name}`
       : (p.booked_by_name ?? ""),

--- a/types/practice.ts
+++ b/types/practice.ts
@@ -8,6 +8,7 @@ export interface Practice {
   location_name: string;
   team_id?: string;
   team_name?: string;
+  booked_by?: string;
   booked_by_name?: string;
   start_at: string;
   end_at: string;
@@ -22,6 +23,7 @@ export interface PracticeRequestDto {
   start_time: string;
   end_time?: string;
   status?: "scheduled" | "completed" | "canceled";
+  booked_by?: string;
 }
 
 export interface PracticeRecurrenceRequestDto {


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->

- Changed practice page
- Changed Practice info panel 
- Changed practice service 
- Changed practice type 

---

# 🧠 Reason for Changes

<!-- Explain why this change was necessary -->
- Practice page – Mapped schedule responses to populate booked_by and booked_by_name so the original booker persists when practices are fetched and refreshed

- Practice info panel – Displayed the booking user and carried the booked_by ID in update requests, keeping the “Booked By” detail intact after edits

- Practice service – Converted API responses to include booked_by and booked_by_name, ensuring booking details accompany practice data from the backend

- Practice type – Added booked_by and booked_by_name fields to practice interfaces so both stored data and request DTOs retain who booked the session
---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [X] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [ ] Backend APIs tested via Postman
- [X] No console errors (Frontend)
- [ ] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---

# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
- https://trello.com/c/7THIbHVs/303-ensure-booked-by-name-stays-updated-after-editing

---



