### PR TITLE
[Chore] Added Roster update functions with styling

### DIFF
--- a/components/teams/RosterEditor.tsx
+++ b/components/teams/RosterEditor.tsx
@@ -16,9 +16,11 @@ import { Customer } from "@/types/customer";
 export default function RosterEditor({
   team,
   onClose,
+  onRosterChange,
 }: {
   team: Team;
   onClose: () => void;
+  onRosterChange?: (members: Team["roster"]) => void;
 }) {
   const { toast } = useToast(); // Initialize toast notifications
   const { user } = useUser(); // Get current user (for auth)
@@ -110,6 +112,7 @@ export default function RosterEditor({
   // Handler for closing the editor: revalidate and call onClose prop
   const handleClose = async () => {
     await revalidateTeams(); // Refresh server data
+    onRosterChange?.(members); // Notify parent of roster change
     onClose(); // Close the editor
   };
 

--- a/components/teams/RosterEditor.tsx
+++ b/components/teams/RosterEditor.tsx
@@ -11,6 +11,7 @@ import { addAthleteToTeam, removeAthleteFromTeam } from "@/services/athletes";
 import { revalidateTeams } from "@/actions/serverActions";
 import { Team } from "@/types/team";
 import { Customer } from "@/types/customer";
+import { SaveIcon } from "lucide-react";
 
 // Main component to edit a team's roster
 export default function RosterEditor({
@@ -181,7 +182,12 @@ export default function RosterEditor({
       {/* Footer with Done button */}
       <Separator className="my-2" />
       <div className="flex justify-end">
-        <Button onClick={handleClose}>Done</Button>
+        <Button
+          onClick={handleClose}
+          className="bg-green-600 hover:bg-green-700"
+        >
+          <SaveIcon className="h-4 w-4 mr-2" /> Save
+        </Button>
       </div>
     </div>
   );

--- a/components/teams/TeamInfoPanel.tsx
+++ b/components/teams/TeamInfoPanel.tsx
@@ -38,6 +38,7 @@ export default function TeamInfoPanel({
   const [capacity, setCapacity] = useState<number>(team.capacity);
   const [coachId] = useState(team.coach_id || "");
   const [rosterOpen, setRosterOpen] = useState(false);
+  const [roster, setRoster] = useState(team.roster);
   const { user } = useUser();
   const { toast } = useToast();
 
@@ -119,16 +120,16 @@ export default function TeamInfoPanel({
             </p>
           </div>
         </div>
-        {team.roster && (
+        {roster && (
           <div>
             <Separator className="my-2" />
             <div className="mt-4 rounded-md border border-yellow-500 p-4 shadow">
               <h3 className="mb-2 text-xl font-semibold">
-                Current Roster ({team.roster.length})
+                Current Roster ({roster.length})
               </h3>
-              {team.roster.length > 0 ? (
+              {roster.length > 0 ? (
                 <ul className="divide-y rounded-md border">
-                  {team.roster.map((member, index) => (
+                  {roster.map((member, index) => (
                     <li key={member.id} className="p-2 even:bg-secondary">
                       {index + 1}. {member.name}
                     </li>
@@ -187,7 +188,11 @@ export default function TeamInfoPanel({
         handleDrawerClose={() => setRosterOpen(false)}
         drawerWidth="w-[50%]"
       >
-        <RosterEditor team={team} onClose={() => setRosterOpen(false)} />
+        <RosterEditor
+          team={{ ...team, roster: roster || [] }}
+          onClose={() => setRosterOpen(false)}
+          onRosterChange={setRoster}
+        />
       </RightDrawer>
     </>
   );


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
- Changed Roster Editor 
- Changed Team info Panel 
- Updated Styling on the roster editor 
---

# 🧠 Reason for Changes

<!-- Explain why this change was necessary -->

- Changed Roster Editor - Added an optional onRosterChange callback that gets invoked when closing the editor so parent components can refresh the roster immediately
- Changed Team Info Panel - Tracks the roster in local state and passes setRoster to the editor’s onRosterChange prop, letting the panel display roster edits in real time without a manual refresh

- Updated Styling on the roster editor - Added the save icon and changed the color to green so the save button matches the styling across the app and keeps it consistent 
---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [X] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [ ] Backend APIs tested via Postman
- [X] No console errors (Frontend)
- [ ] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---



# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
- https://trello.com/c/IjkanB8T/308-add-auto-update-so-roster-changes-are-visualized-right-away

---



