### PR TITLE
[Chore] Switch to secure teams endpoint

### DIFF
--- a/app/(dashboard)/manage/teams/page.tsx
+++ b/app/(dashboard)/manage/teams/page.tsx
@@ -1,10 +1,31 @@
+"use client";
+
 import TeamsPage from "@/components/teams/TeamsPage";
 import RoleProtected from "@/components/RoleProtected";
-import { getAllTeams } from "@/services/teams";
+import { getUserTeams } from "@/services/teams";
 import { StaffRoleEnum } from "@/types/user";
+import { useEffect, useState } from "react";
+import { useUser } from "@/contexts/UserContext";
+import { Team } from "@/types/team";
 
-export default async function Page() {
-  const teams = await getAllTeams();
+export default function Page() {
+  const [teams, setTeams] = useState<Team[]>([]);
+  const { user } = useUser();
+
+  useEffect(() => {
+    const fetchTeams = async () => {
+      try {
+        if (user?.Jwt) {
+          const data = await getUserTeams(user.Jwt);
+          setTeams(data);
+        }
+      } catch (error) {
+        console.error("Failed to fetch teams", error);
+      }
+    };
+
+    fetchTeams();
+  }, [user]);
 
   return (
     <RoleProtected allowedRoles={[StaffRoleEnum.ADMIN, StaffRoleEnum.COACH]}>

--- a/components/practices/AddPracticeForm.tsx
+++ b/components/practices/AddPracticeForm.tsx
@@ -16,7 +16,7 @@ import {
   PracticeRecurrenceRequestDto,
 } from "@/types/practice";
 import { getAllLocations } from "@/services/location";
-import { getAllTeams } from "@/services/teams";
+import { getUserTeams } from "@/services/teams";
 import { getAllCourts } from "@/services/court";
 import { Location } from "@/types/location";
 import { Team } from "@/types/team";
@@ -57,12 +57,13 @@ export default function AddPracticeForm({
   const [mode, setMode] = useState<"once" | "recurring">("once");
 
   useEffect(() => {
+    if (!user?.Jwt) return;
     // Fetch available teams and locations for the dropdown lists
     const fetchLists = async () => {
       try {
         const [locs, tms, crts] = await Promise.all([
           getAllLocations(),
-          getAllTeams(),
+          getUserTeams(user.Jwt),
           getAllCourts(),
         ]);
         setLocations(locs);
@@ -74,7 +75,7 @@ export default function AddPracticeForm({
     };
 
     fetchLists();
-  }, []);
+  }, [user?.Jwt]);
 
   // Create the practice using the chosen mode
   const handleAddPractice = async () => {

--- a/components/practices/PracticeInfoPanel.tsx
+++ b/components/practices/PracticeInfoPanel.tsx
@@ -23,7 +23,7 @@ import { useFormData } from "@/hooks/form-data";
 import { updatePractice, deletePractice } from "@/services/practices";
 import { PracticeRequestDto } from "@/types/practice";
 import { getAllLocations } from "@/services/location";
-import { getAllTeams } from "@/services/teams";
+import { getUserTeams } from "@/services/teams";
 import { getAllCourts } from "@/services/court";
 import { revalidatePractices } from "@/actions/serverActions";
 import { Practice } from "@/types/practice";
@@ -70,12 +70,13 @@ export default function PracticeInfoPanel({
   );
 
   useEffect(() => {
+    if (!user?.Jwt) return;
     // Load dropdown options for editing the practice
     const fetchLists = async () => {
       try {
         const [locs, tms, crts] = await Promise.all([
           getAllLocations(),
-          getAllTeams(),
+          getUserTeams(user.Jwt),
           getAllCourts(),
         ]);
         setLocations(locs);
@@ -87,7 +88,7 @@ export default function PracticeInfoPanel({
     };
 
     fetchLists();
-  }, []);
+  }, [user?.Jwt]);
 
   // Persist any changes made to the practice
   const handleSave = async () => {

--- a/components/teams/TeamsPage.tsx
+++ b/components/teams/TeamsPage.tsx
@@ -4,6 +4,7 @@
 // table display and the drawer for viewing or adding a team.
 
 import { useState } from "react";
+import { useUser } from "@/contexts/UserContext";
 import { Heading } from "@/components/ui/Heading";
 import { Separator } from "@/components/ui/separator";
 import { Input } from "@/components/ui/input";
@@ -32,6 +33,7 @@ export default function TeamsPage({ teams }: { teams: Team[] }) {
   );
   const [searchQuery, setSearchQuery] = useState("");
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({});
+  const { user } = useUser();
 
   const filteredTeams = searchQuery
     ? teams.filter((team) =>
@@ -41,7 +43,8 @@ export default function TeamsPage({ teams }: { teams: Team[] }) {
 
   // Open the drawer and load the selected team's full details, including roster
   const handleTeamSelect = (team: Team) => {
-    getTeamById(team.id)
+    if (!user?.Jwt) return;
+    getTeamById(team.id, user.Jwt)
       .then((fullTeam) => {
         setSelectedTeam(fullTeam);
       })

--- a/services/teams.ts
+++ b/services/teams.ts
@@ -6,7 +6,6 @@ import { TeamResponse, TeamRequestDto } from "@/app/api/Api";
 export async function getAllTeams(): Promise<Team[]> {
   try {
     const response = await fetch(`${getValue("API")}teams`);
-
     const responseJSON = await response.json();
 
     if (!response.ok) {
@@ -20,8 +19,8 @@ export async function getAllTeams(): Promise<Team[]> {
     return (responseJSON as TeamResponse[]).map((team) => ({
       id: team.id!,
       name: team.name!,
-      created_at: new Date(team.created_at!), // Convert string to Date
-      updated_at: new Date(team.updated_at!), // Convert string to Date
+      created_at: new Date(team.created_at!),
+      updated_at: new Date(team.updated_at!),
       capacity: team.capacity!,
       coach_id: team.coach?.id!,
       coach_name: team.coach?.name || "",
@@ -32,9 +31,41 @@ export async function getAllTeams(): Promise<Team[]> {
   }
 }
 
-export async function getTeamById(id: string): Promise<Team> {
+export async function getUserTeams(jwt: string): Promise<Team[]> {
   try {
-    const response = await fetch(`${getValue("API")}teams/${id}`);
+    const response = await fetch(`${getValue("API")}secure/teams`, {
+      ...addAuthHeader(jwt),
+    });
+    const responseJSON = await response.json();
+
+    if (!response.ok) {
+      let errorMessage = `Failed to get teams: ${response.statusText}`;
+      if (responseJSON.error) {
+        errorMessage = responseJSON.error.message;
+      }
+      throw new Error(errorMessage);
+    }
+
+    return (responseJSON as TeamResponse[]).map((team) => ({
+      id: team.id!,
+      name: team.name!,
+      created_at: new Date(team.created_at!),
+      updated_at: new Date(team.updated_at!),
+      capacity: team.capacity!,
+      coach_id: team.coach?.id!,
+      coach_name: team.coach?.name || "",
+    }));
+  } catch (error) {
+    console.error("Error fetching teams:", error);
+    throw error;
+  }
+}
+
+export async function getTeamById(id: string, jwt: string): Promise<Team> {
+  try {
+    const response = await fetch(`${getValue("API")}teams/${id}`, {
+      ...addAuthHeader(jwt),
+    });
     const data: TeamResponse = await response.json();
 
     if (!response.ok) {


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
- Changed teams page 
- Changed add practice form
- Changed practice info panel
- Changed teams page component 
- Changed teams service 
---

# 🧠 Reason for Changes

<!-- Explain why this change was necessary -->
- Changed teams page – The dashboard teams page now requests teams with the logged‑in coach’s JWT via getUserTeams, ensuring only that coach’s teams are listed

- Changed add practice form – The practice creation form retrieves team options with getUserTeams, so coaches can assign a practice only to their own teams

- Changed practice info panel – When editing a practice, the info panel fetches available teams through getUserTeams to prevent switching a practice to another coach’s team

- Changed teams page component – Selecting a team now fetches full details using the current user’s JWT, blocking unauthorized users from viewing or editing other coaches’ teams

- Changed teams service – Introduced an authenticated getUserTeams function and redirected getTeamById to the public /teams/:id endpoint, aligning service calls with the new security model
---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [X] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [ ] Backend APIs tested via Postman
- [X] No console errors (Frontend)
- [ ] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---


# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
- https://trello.com/c/FdEajTsJ/309-update-teams-endpoint-to-secure-for-role-based-viewing

---


