### PR TITLE
[Chore] Add no store for cache on teams and staff pages

### DIFF
--- a/app/(dashboard)/manage/barbershop/page.tsx
+++ b/app/(dashboard)/manage/barbershop/page.tsx
@@ -4,8 +4,9 @@ import RoleProtected from "@/components/RoleProtected";
 import { StaffRoleEnum } from "@/types/user";
 import { getAllStaffs } from "@/services/staff";
 
-export default async function BarbershopPageContainer() {
+export const revalidate = 0;
 
+export default async function BarbershopPageContainer() {
   const staffData = await getAllStaffs(StaffRoleEnum.BARBER.toUpperCase());
 
   return (
@@ -13,7 +14,7 @@ export default async function BarbershopPageContainer() {
       allowedRoles={[StaffRoleEnum.ADMIN, StaffRoleEnum.BARBER]}
       fallback={<PageSkeleton />}
     >
-      <BarbershopPage staffs={staffData}/>
+      <BarbershopPage staffs={staffData} />
     </RoleProtected>
   );
 }
@@ -32,13 +33,13 @@ function PageSkeleton() {
       <Skeleton className="h-px w-full" />
 
       <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4">
-        {[1, 2, 3, 4].map(i => (
+        {[1, 2, 3, 4].map((i) => (
           <Skeleton key={i} className="h-24 w-full rounded-lg" />
         ))}
       </div>
 
       <div className="flex gap-4 mt-4">
-        {[1, 2, 3].map(i => (
+        {[1, 2, 3].map((i) => (
           <Skeleton key={i} className="h-10 w-36" />
         ))}
       </div>

--- a/app/(dashboard)/manage/staff/page.tsx
+++ b/app/(dashboard)/manage/staff/page.tsx
@@ -4,8 +4,6 @@ import StaffPage from "@/components/staff/StaffPage";
 import PendingStaffContainer from "@/components/pending-staff/PendingStaffContainer";
 import RoleProtected from "@/components/RoleProtected";
 
-export const revalidate = 0;
-
 export default async function Page() {
   const staffs = await getAllStaffs();
   return (

--- a/app/(dashboard)/manage/staff/page.tsx
+++ b/app/(dashboard)/manage/staff/page.tsx
@@ -4,6 +4,8 @@ import StaffPage from "@/components/staff/StaffPage";
 import PendingStaffContainer from "@/components/pending-staff/PendingStaffContainer";
 import RoleProtected from "@/components/RoleProtected";
 
+export const revalidate = 0;
+
 export default async function Page() {
   const staffs = await getAllStaffs();
   return (

--- a/services/staff.ts
+++ b/services/staff.ts
@@ -9,7 +9,7 @@ export async function getAllStaffs(roleFilter?: string): Promise<User[]> {
       ? `${getValue("API")}staffs?role=${roleFilter}`
       : `${getValue("API")}staffs`;
 
-    const response = await fetch(url);
+    const response = await fetch(url, { cache: "no-store" });
 
     const responseJson = await response.json();
 
@@ -102,6 +102,7 @@ export async function getPendingStaffs(jwt: string): Promise<User[]> {
   try {
     const response = await fetch(`${getValue("API")}register/staff/pending`, {
       ...addAuthHeader(jwt),
+      cache: "no-store",
     });
 
     const responseJson = await response.json();

--- a/services/teams.ts
+++ b/services/teams.ts
@@ -5,7 +5,9 @@ import { TeamResponse, TeamRequestDto } from "@/app/api/Api";
 
 export async function getAllTeams(): Promise<Team[]> {
   try {
-    const response = await fetch(`${getValue("API")}teams`);
+    const response = await fetch(`${getValue("API")}teams`, {
+      cache: "no-store",
+    });
     const responseJSON = await response.json();
 
     if (!response.ok) {
@@ -35,6 +37,7 @@ export async function getUserTeams(jwt: string): Promise<Team[]> {
   try {
     const response = await fetch(`${getValue("API")}secure/teams`, {
       ...addAuthHeader(jwt),
+      cache: "no-store",
     });
     const responseJSON = await response.json();
 
@@ -65,6 +68,7 @@ export async function getTeamById(id: string, jwt: string): Promise<Team> {
   try {
     const response = await fetch(`${getValue("API")}teams/${id}`, {
       ...addAuthHeader(jwt),
+      cache: "no-store",
     });
     const data: TeamResponse = await response.json();
 


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->

- Changed staff page
- Changed staff service 
- Changed teams service 
- Changed barber page
---

# 🧠 Reason for Changes

<!-- Explain why this change was necessary -->
- Changed staff page – Adding revalidate = 0 stops Next.js from serving a cached staff management page so newly approved staff appear right away

- Changed staff service – Staff API calls now set cache: "no-store" to pull fresh data for both the main list and pending approvals instead of relying on cached responses

- Changed teams service – Team fetch functions disable caching with cache: "no-store" so team lists and details always reflect the latest updates

- Adding export const revalidate = 0; makes the barbershop management page fully dynamic, preventing stale content by disabling caching
---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [X] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [ ] Backend APIs tested via Postman
- [X] No console errors (Frontend)
- [ ] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---



# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
- https://trello.com/c/GZQi9lUC/311-add-no-cache-for-staff-and-teams

---



