### PR TITLE
[Chore] Fix Membership Plan Price display 

### DIFF
--- a/components/memberships/infoTabs/plans/Plans.tsx
+++ b/components/memberships/infoTabs/plans/Plans.tsx
@@ -257,7 +257,7 @@ export default function PlansTab({ membershipId }: { membershipId: string }) {
                       Price
                     </h1>
                     <h1 className="text-stone-500 font-medium text-sm pt-1 pr-1">
-                      {plan.price ?? 0}
+                      {formatPrice(plan.price ?? 0)}
                     </h1>
                     <h1 className="text-stone-500 font-semibold text-sm pt-1">
                       • Every {plan.amt_periods} Months

--- a/services/membershipPlan.ts
+++ b/services/membershipPlan.ts
@@ -18,6 +18,17 @@ export async function getPlansForMembership(
 
     const data: MembershipPlanPlanResponse[] = await res.json();
 
+    // Ensure numeric values for price-related fields to avoid NaN when formatting
+    const parseNumber = (value: unknown): number => {
+      if (typeof value === "number") return value;
+      if (typeof value === "string") {
+        const cleaned = value.replace(/[^0-9.-]+/g, "");
+        const parsed = parseFloat(cleaned);
+        return isNaN(parsed) ? 0 : parsed;
+      }
+      return 0;
+    };
+
     return data.map((plan) => ({
       id: plan.id!,
       membership_id: plan.membership_id!,
@@ -25,8 +36,8 @@ export async function getPlansForMembership(
       stripe_price_id: plan.stripe_price_id || "",
       stripe_joining_fees_id: plan.stripe_joining_fees_id || "",
       amt_periods: plan.amt_periods || 0,
-      price: (plan as any).price ?? 0,
-      joining_fee: (plan as any).joining_fee ?? 0,
+      price: parseNumber((plan as any).price),
+      joining_fee: parseNumber((plan as any).joining_fee),
     }));
   } catch (err) {
     console.error("🔥 Error loading membership plans:", err);


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
- Changed membership plan info tab
- Changed membership plan service 
---

# 🧠 Reason for Changes

<!-- Explain why this change was necessary -->
- Membership plan info tab - A formatPrice helper now formats each plan’s price before render, ensuring the header always shows a valid CAD amount instead of “CA$NaN”

- Membership plan service - A parseNumber utility sanitizes API price fields into numbers, preventing “NaN” values when formatting plan price and joining fee
---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [X] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [ ] Backend APIs tested via Postman
- [X] No console errors (Frontend)
- [ ] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---



# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
- https://trello.com/c/DDFM5Y9l/286-fix-displaying-membership-plan-price

---


