### PR TITLE
[Feature] Added 48 hour save for check in logs

### DIFF
--- a/components/checkin/CheckInPage.tsx
+++ b/components/checkin/CheckInPage.tsx
@@ -8,6 +8,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Card, CardContent } from "@/components/ui/card";
 import LoginLogTable from "@/components/checkin/table/LoginLogTable";
 import { LoginLog } from "@/types/login-logs";
+import { loadLogs, saveLogs } from "@/utils/checkinLogs";
 import {
   AlertDialog,
   AlertDialogContent,
@@ -30,6 +31,10 @@ export default function CheckInPage() {
   }, []);
 
   useEffect(() => {
+    setLoginLogs(loadLogs());
+  }, []);
+
+  useEffect(() => {
     if (showNoMembershipAlert) {
       const timer = setTimeout(() => setShowNoMembershipAlert(false), 3000);
       return () => clearTimeout(timer);
@@ -49,15 +54,19 @@ export default function CheckInPage() {
       const customerData = await getCustomerById(customerId);
       if (customerData) {
         setCustomer(customerData);
-        setLoginLogs((prev) => [
-          {
-            id: customerData.id,
-            name: `${customerData.first_name} ${customerData.last_name}`,
-            email: customerData.email,
-            loginTime: new Date().toISOString(),
-          },
-          ...prev,
-        ]);
+        setLoginLogs((prev) => {
+          const updated = [
+            {
+              id: customerData.id,
+              name: `${customerData.first_name} ${customerData.last_name}`,
+              email: customerData.email,
+              loginTime: new Date().toISOString(),
+            },
+            ...prev,
+          ];
+          saveLogs(updated);
+          return updated;
+        });
       } else {
         setCustomer(null);
       }

--- a/utils/checkinLogs.ts
+++ b/utils/checkinLogs.ts
@@ -1,0 +1,26 @@
+import { LoginLog } from "@/types/login-logs";
+
+const FORTY_EIGHT_HOURS = 48 * 60 * 60 * 1000;
+
+function pruneOldLogs(logs: LoginLog[]): LoginLog[] {
+  const cutoff = Date.now() - FORTY_EIGHT_HOURS;
+  return logs.filter((log) => new Date(log.loginTime).getTime() >= cutoff);
+}
+
+export function loadLogs(): LoginLog[] {
+  if (typeof window === "undefined") return [];
+  const stored = localStorage.getItem("checkinLogs");
+  if (!stored) return [];
+  try {
+    const logs: LoginLog[] = JSON.parse(stored);
+    return pruneOldLogs(logs);
+  } catch {
+    return [];
+  }
+}
+
+export function saveLogs(logs: LoginLog[]): void {
+  if (typeof window === "undefined") return;
+  const pruned = pruneOldLogs(logs);
+  localStorage.setItem("checkinLogs", JSON.stringify(pruned));
+}


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
- Created Check in logs util
- Changed check in page 

---

# 🧠 Reason for Changes

<!-- Explain why this change was necessary -->
- Created Check‑in logs util - centralizes loading and saving check‑in records in localStorage, pruning entries older than 48 hours so only recent activity persists

- Changed Check‑in page - initializes the log state from stored entries and writes back each new check‑in so records survive page reloads or token refreshes
---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [X] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [ ] Backend APIs tested via Postman
- [X] No console errors (Frontend)
- [ ] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---


# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
- https://trello.com/c/mbsNo8Nt/313-save-check-in-logs-for-48-hours

---



