### PR TITLE
[Chore] Made courts optional for booking a practice

### DIFF
--- a/components/practices/AddPracticeForm.tsx
+++ b/components/practices/AddPracticeForm.tsx
@@ -79,10 +79,10 @@ export default function AddPracticeForm({
 
   // Create the practice using the chosen mode
   const handleAddPractice = async () => {
-    if (!data.team_id || !data.location_id || !data.court_id) {
+    if (!data.team_id || !data.location_id) {
       toast({
         status: "error",
-        description: "Team, location and court are required",
+        description: "Team and location are required",
         variant: "destructive",
       });
       return;
@@ -101,7 +101,7 @@ export default function AddPracticeForm({
       }
 
       const practiceData: PracticeRequestDto = {
-        court_id: data.court_id,
+        court_id: data.court_id || undefined,
         location_id: data.location_id,
         team_id: data.team_id,
         start_time: toZonedISOString(new Date(data.start_at)),
@@ -133,7 +133,7 @@ export default function AddPracticeForm({
       };
 
       const practiceData: PracticeRecurrenceRequestDto = {
-        court_id: data.court_id,
+        court_id: data.court_id || undefined,
         location_id: data.location_id,
         team_id: data.team_id,
         recurrence_start_at: toZonedISOString(
@@ -213,9 +213,7 @@ export default function AddPracticeForm({
             value={data.court_id}
             onChange={(e) => updateField("court_id", e.target.value)}
           >
-            <option value="" disabled>
-              Select court
-            </option>
+            <option value="">Select court</option>
             {filteredCourts.map((court) => (
               <option key={court.id} value={court.id}>
                 {court.name}

--- a/components/practices/PracticeInfoPanel.tsx
+++ b/components/practices/PracticeInfoPanel.tsx
@@ -92,10 +92,10 @@ export default function PracticeInfoPanel({
 
   // Persist any changes made to the practice
   const handleSave = async () => {
-    if (!data.team_id || !data.location_id || !data.court_id) {
+    if (!data.team_id || !data.location_id) {
       toast({
         status: "error",
-        description: "Team, location and court are required",
+        description: "Team and location are required",
         variant: "destructive",
       });
       return;
@@ -111,7 +111,7 @@ export default function PracticeInfoPanel({
     }
 
     const practiceData: PracticeRequestDto = {
-      court_id: data.court_id,
+      court_id: data.court_id || undefined,
       location_id: data.location_id,
       team_id: data.team_id,
       start_time: toZonedISOString(new Date(data.start_at)),
@@ -207,9 +207,7 @@ export default function PracticeInfoPanel({
             value={data.court_id}
             onChange={(e) => updateField("court_id", e.target.value)}
           >
-            <option value="" disabled>
-              Select court
-            </option>
+            <option value="">Select court</option>
             {filteredCourts.map((court) => (
               <option key={court.id} value={court.id}>
                 {court.name}

--- a/components/practices/table/columns.tsx
+++ b/components/practices/table/columns.tsx
@@ -26,6 +26,7 @@ const columns: ColumnDef<Practice>[] = [
     id: "court_name",
     accessorKey: "court_name",
     header: "Court",
+    cell: ({ row }) => row.getValue("court_name") || "-",
     minSize: 120,
     size: 180,
   },

--- a/types/practice.ts
+++ b/types/practice.ts
@@ -17,7 +17,7 @@ export interface Practice {
 }
 
 export interface PracticeRequestDto {
-  court_id: string;
+  court_id?: string;
   location_id: string;
   team_id: string;
   start_time: string;
@@ -27,7 +27,7 @@ export interface PracticeRequestDto {
 }
 
 export interface PracticeRecurrenceRequestDto {
-  court_id: string;
+  court_id?: string;
   location_id: string;
   team_id: string;
   day?: string;


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
- Changed add practice form
- Changed practice info panel 
- Changed practice table 
- Changed practice type 

---

# 🧠 Reason for Changes

<!-- Explain why this change was necessary -->
- Changed add practice form: The form was updated so users can create practices without selecting a court, reflecting that a court is now optional.

- Changed practice info panel: The panel now conditionally shows and submits court information only when present, ensuring edits respect optional court assignments.

- Changed practice table: A placeholder dash is displayed when a practice lacks a court, clearly indicating unassigned court entries in the table.

- Changed practice type: The practice request types were modified to make the court ID optional so backend calls accept practices without a court.
---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [X] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [ ] Backend APIs tested via Postman
- [X] No console errors (Frontend)
- [ ] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---


# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
- https://trello.com/c/QICg4gQC/315-make-court-optional-for-practice

---



