### PR TITLE
[Chore] Changed first day of the week to Sunday

### DIFF
--- a/components/calendar/body/month/calendar-body-month.tsx
+++ b/components/calendar/body/month/calendar-body-month.tsx
@@ -24,10 +24,10 @@ export default function CalendarBodyMonth() {
   // Get the last day of the month
   const monthEnd = endOfMonth(date);
 
-  // Get the first Monday of the first week (may be in previous month)
-  const calendarStart = startOfWeek(monthStart, { weekStartsOn: 1 });
-  // Get the last Sunday of the last week (may be in next month)
-  const calendarEnd = endOfWeek(monthEnd, { weekStartsOn: 1 });
+  // Get the first Sunday of the first week (may be in previous month)
+  const calendarStart = startOfWeek(monthStart, { weekStartsOn: 0 });
+  // Get the last Saturday of the last week (may be in next month)
+  const calendarEnd = endOfWeek(monthEnd, { weekStartsOn: 0 });
 
   // Get all days between start and end
   const calendarDays = eachDayOfInterval({
@@ -50,7 +50,7 @@ export default function CalendarBodyMonth() {
   return (
     <div className="flex flex-col flex-grow overflow-hidden">
       <div className="hidden md:grid grid-cols-7 border-border divide-x divide-border">
-        {["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"].map((day) => (
+        {["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"].map((day) => (
           <div
             key={day}
             className="py-2 text-center text-sm font-medium text-muted-foreground border-b border-border"

--- a/components/calendar/body/week/calendar-body-week.tsx
+++ b/components/calendar/body/week/calendar-body-week.tsx
@@ -1,12 +1,12 @@
-import { useCalendarContext } from '../../calendar-context'
-import { startOfWeek, addDays } from 'date-fns'
-import CalendarBodyMarginDayMargin from '../day/calendar-body-margin-day-margin'
-import CalendarBodyDayContent from '../day/calendar-body-day-content'
+import { useCalendarContext } from "../../calendar-context";
+import { startOfWeek, addDays } from "date-fns";
+import CalendarBodyMarginDayMargin from "../day/calendar-body-margin-day-margin";
+import CalendarBodyDayContent from "../day/calendar-body-day-content";
 export default function CalendarBodyWeek() {
-  const { date } = useCalendarContext()
+  const { date } = useCalendarContext();
 
-  const weekStart = startOfWeek(date, { weekStartsOn: 1 })
-  const weekDays = Array.from({ length: 7 }, (_, i) => addDays(weekStart, i))
+  const weekStart = startOfWeek(date, { weekStartsOn: 0 });
+  const weekDays = Array.from({ length: 7 }, (_, i) => addDays(weekStart, i));
 
   return (
     <div className="flex divide-x flex-grow overflow-hidden">
@@ -27,5 +27,5 @@ export default function CalendarBodyWeek() {
         </div>
       </div>
     </div>
-  )
+  );
 }


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
- Changed body month and week
---

# 🧠 Reason for Changes

<!-- Explain why this change was necessary -->
- The calendar previously calculated weeks starting on Monday, causing the weekly and monthly views to misalign with users in regions (like the U.S.) where weeks begin on Sunday. By anchoring both views to Sunday, the displayed dates and weekday headers now align with a Sunday‑first convention, eliminating mismatches.
---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [X] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [ ] Backend APIs tested via Postman
- [X] No console errors (Frontend)
- [ ] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---



# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
- https://trello.com/c/cclgbjyX/316-change-calendar-so-sunday-is-first
---


