### PR TITLE
[Feature] Added home and away score functionality for Games

### DIFF
--- a/components/games/GameInfoPanel.tsx
+++ b/components/games/GameInfoPanel.tsx
@@ -45,6 +45,14 @@ export default function GameInfoPanel({
   const { data, updateField } = useFormData({
     home_team_id: game.home_team_id,
     away_team_id: game.away_team_id,
+    home_score:
+      game.home_score !== null && game.home_score !== undefined
+        ? String(game.home_score)
+        : "",
+    away_score:
+      game.away_score !== null && game.away_score !== undefined
+        ? String(game.away_score)
+        : "",
     location_id: game.location_id,
     court_id: game.court_id || "",
     start_time: toLocalISOString(fromZonedISOString(game.start_time)).slice(
@@ -105,6 +113,8 @@ export default function GameInfoPanel({
     const gameData = {
       home_team_id: data.home_team_id,
       away_team_id: data.away_team_id,
+      home_score: data.home_score === "" ? null : Number(data.home_score),
+      away_score: data.away_score === "" ? null : Number(data.away_score),
       location_id: data.location_id,
       court_id: data.court_id ? data.court_id : null,
       start_time: toZonedISOString(new Date(data.start_time)),
@@ -179,6 +189,22 @@ export default function GameInfoPanel({
               </option>
             ))}
           </select>
+        </div>
+        <div className="space-y-2">
+          <label className="text-sm font-medium">Home Score</label>
+          <Input
+            value={data.home_score}
+            onChange={(e) => updateField("home_score", e.target.value)}
+            type="number"
+          />
+        </div>
+        <div className="space-y-2">
+          <label className="text-sm font-medium">Away Score</label>
+          <Input
+            value={data.away_score}
+            onChange={(e) => updateField("away_score", e.target.value)}
+            type="number"
+          />
         </div>
         <div className="space-y-2">
           <label className="text-sm font-medium">Location</label>

--- a/components/games/table/columns.tsx
+++ b/components/games/table/columns.tsx
@@ -22,6 +22,18 @@ const columns: ColumnDef<Game>[] = [
     size: 250,
   },
   {
+    id: "score",
+    header: "Score",
+    cell: ({ row }) => {
+      const { home_score, away_score } = row.original;
+      return home_score !== null && away_score !== null
+        ? `${home_score} - ${away_score}`
+        : "TBD";
+    },
+    minSize: 80,
+    size: 100,
+  },
+  {
     id: "location_name",
     accessorKey: "location_name",
     header: "Location",

--- a/services/games.ts
+++ b/services/games.ts
@@ -18,8 +18,8 @@ export async function getAllGames(): Promise<Game[]> {
       away_team_id: g.away_team_id!, // Required away team ID
       away_team_name: g.away_team_name!, // Required away team name
       away_team_logo_url: g.away_team_logo_url || "", // Optional logo URL
-      home_score: g.home_score, // Score values can be null/undefined
-      away_score: g.away_score,
+      home_score: g.home_score ?? null, // Normalize missing scores to null
+      away_score: g.away_score ?? null,
       start_time: g.start_time, // Event start timestamp
       end_time: g.end_time, // Event end timestamp
       location_id: g.location_id!, // Required location ID

--- a/types/games.ts
+++ b/types/games.ts
@@ -6,8 +6,8 @@ export interface Game {
   away_team_id: string;
   away_team_name: string;
   away_team_logo_url: string;
-  home_score: number;
-  away_score: number;
+  home_score: number | null;
+  away_score: number | null;
   start_time: string;
   end_time: string;
   location_id: string;


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
- Added to Game info panel
- Added to games table
- Changed games service
- Changed games types
---

# 🧠 Reason for Changes

<!-- Explain why this change was necessary -->
- Added to GameInfoPanel: Enabled editing and saving of home and away scores so game details can include results directly within the panel.
- Added to games table: Introduced a score column to display recorded results or “TBD,” making the table reflect current game outcomes.
- Changed games service: Normalized missing score data to null to ensure consistent handling of optional scores from the API.
- Changed games types: Allowed home_score and away_score to be number | null so the model accommodates unplayed or pending games.
---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [X] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [ ] Backend APIs tested via Postman
- [X] No console errors (Frontend)
- [ ] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---



# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
- https://trello.com/c/IGUDT1UG/323-add-home-and-away-score-for-games

---



