### PR TITLE
[Chore] Updated Teams page so when CRUD operations happen the Teams table will update in real time 

### DIFF
--- a/app/(dashboard)/manage/teams/page.tsx
+++ b/app/(dashboard)/manage/teams/page.tsx
@@ -4,7 +4,7 @@ import TeamsPage from "@/components/teams/TeamsPage";
 import RoleProtected from "@/components/RoleProtected";
 import { getUserTeams } from "@/services/teams";
 import { StaffRoleEnum } from "@/types/user";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useUser } from "@/contexts/UserContext";
 import { Team } from "@/types/team";
 
@@ -12,25 +12,25 @@ export default function Page() {
   const [teams, setTeams] = useState<Team[]>([]);
   const { user } = useUser();
 
-  useEffect(() => {
-    const fetchTeams = async () => {
-      try {
-        if (user?.Jwt) {
-          const data = await getUserTeams(user.Jwt);
-          setTeams(data);
-        }
-      } catch (error) {
-        console.error("Failed to fetch teams", error);
+  const fetchTeams = useCallback(async () => {
+    try {
+      if (user?.Jwt) {
+        const data = await getUserTeams(user.Jwt);
+        setTeams(data);
       }
-    };
-
-    fetchTeams();
+    } catch (error) {
+      console.error("Failed to fetch teams", error);
+    }
   }, [user]);
+
+  useEffect(() => {
+    fetchTeams();
+  }, [fetchTeams]);
 
   return (
     <RoleProtected allowedRoles={[StaffRoleEnum.ADMIN, StaffRoleEnum.COACH]}>
       <div className="flex">
-        <TeamsPage teams={teams} />
+        <TeamsPage teams={teams} refreshTeams={fetchTeams} />
       </div>
     </RoleProtected>
   );

--- a/components/teams/AddTeamForm.tsx
+++ b/components/teams/AddTeamForm.tsx
@@ -22,7 +22,13 @@ import { revalidateTeams } from "@/actions/serverActions";
 import { User } from "@/types/user";
 import { useEffect, useState } from "react";
 
-export default function AddTeamForm({ onClose }: { onClose?: () => void }) {
+export default function AddTeamForm({
+  onClose,
+  onTeamAdded,
+}: {
+  onClose?: () => void;
+  onTeamAdded?: () => void;
+}) {
   // useFormData provides a simple object based form state manager
   // with helpers for updating and resetting the data fields.
   const { data, updateField, resetData } = useFormData({
@@ -92,6 +98,7 @@ export default function AddTeamForm({ onClose }: { onClose?: () => void }) {
         setLogoData("");
         setLogoName("");
         await revalidateTeams();
+        onTeamAdded?.();
         if (onClose) onClose();
       } else {
         toast({

--- a/components/teams/TeamInfoPanel.tsx
+++ b/components/teams/TeamInfoPanel.tsx
@@ -30,9 +30,11 @@ import { TeamRequestDto } from "@/app/api/Api";
 export default function TeamInfoPanel({
   team,
   onClose,
+  onTeamChanged,
 }: {
   team: Team;
   onClose?: () => void;
+  onTeamChanged?: () => void;
 }) {
   const [name, setName] = useState(team.name);
   const [capacity, setCapacity] = useState<number>(team.capacity);
@@ -59,6 +61,7 @@ export default function TeamInfoPanel({
       if (error === null) {
         toast({ status: "success", description: "Team updated successfully" });
         await revalidateTeams();
+        onTeamChanged?.();
         onClose?.();
       } else {
         toast({
@@ -83,6 +86,7 @@ export default function TeamInfoPanel({
       if (error === null) {
         toast({ status: "success", description: "Team deleted successfully" });
         await revalidateTeams();
+        onTeamChanged?.();
         if (onClose) onClose();
       } else {
         toast({

--- a/components/teams/TeamsPage.tsx
+++ b/components/teams/TeamsPage.tsx
@@ -25,7 +25,13 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { ChevronDown } from "lucide-react";
 
-export default function TeamsPage({ teams }: { teams: Team[] }) {
+export default function TeamsPage({
+  teams,
+  refreshTeams,
+}: {
+  teams: Team[];
+  refreshTeams: () => void;
+}) {
   const [selectedTeam, setSelectedTeam] = useState<Team | null>(null);
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [drawerContent, setDrawerContent] = useState<"details" | "add" | null>(
@@ -138,10 +144,14 @@ export default function TeamsPage({ teams }: { teams: Team[] }) {
             <TeamInfoPanel
               team={selectedTeam}
               onClose={() => setDrawerOpen(false)}
+              onTeamChanged={refreshTeams}
             />
           )}
           {drawerContent === "add" && (
-            <AddTeamForm onClose={() => setDrawerOpen(false)} />
+            <AddTeamForm
+              onClose={() => setDrawerOpen(false)}
+              onTeamAdded={refreshTeams}
+            />
           )}
         </div>
       </RightDrawer>


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
- Changed Teams Page
- Changed add team form
- Changed team info panel 
- Changed teams page component 
---

# 🧠 Reason for Changes

<!-- Explain why this change was necessary -->
- Changed Teams Page: Introduced a reusable fetchTeams callback so the page automatically reloads the team list after any CRUD operation.

- Changed Add Team Form: Added an onTeamAdded hook that re-fetches teams once a new team is created, eliminating the need for a manual page refresh.

- Changed Team Info Panel: Added an onTeamChanged notifier to refresh the team list whenever a team is edited or deleted.

- Changed Teams Page Component: Plumbed the refresh callback through the main TeamsPage component, passing it to add and edit drawers to keep the table in sync without reloading.
---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [X] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [ ] Backend APIs tested via Postman
- [X] No console errors (Frontend)
- [ ] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---



# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
- https://trello.com/c/parbPWW6/327-team-auto-updates

---


