### PR TITLE
[Feature] Staff enrolment for events

### DIFF
--- a/components/calendar/dialog/calendar-manage-event-drawer.tsx
+++ b/components/calendar/dialog/calendar-manage-event-drawer.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import { Separator } from "@/components/ui/separator";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import { Info, UserRound } from "lucide-react";
 import RightDrawer from "@/components/reusable/RightDrawer";
 import { useCalendarContext } from "../calendar-context";
 import EditEventForm from "../event/EditEventForm";
@@ -120,9 +121,21 @@ export default function CalendarManageEventDrawer() {
             }}
             className="space-y-6"
           >
-            <TabsList className="grid w-full grid-cols-2">
-              <TabsTrigger value="details">Details</TabsTrigger>
-              <TabsTrigger value="staff">Staff</TabsTrigger>
+            <TabsList className="w-full h-auto p-0 bg-transparent flex gap-1 rounded-none border-b border-border">
+              <TabsTrigger
+                value="details"
+                className="flex items-center gap-2 px-6 py-3 rounded-none bg-transparent hover:bg-muted/50 transition-all data-[state=active]:border-b-2 data-[state=active]:border-primary data-[state=active]:text-primary data-[state=active]:shadow-none"
+              >
+                <Info className="h-4 w-4" />
+                Details
+              </TabsTrigger>
+              <TabsTrigger
+                value="staff"
+                className="flex items-center gap-2 px-6 py-3 rounded-none bg-transparent hover:bg-muted/50 transition-all data-[state=active]:border-b-2 data-[state=active]:border-primary data-[state=active]:text-primary data-[state=active]:shadow-none"
+              >
+                <UserRound className="h-4 w-4" />
+                Staff
+              </TabsTrigger>
             </TabsList>
             <TabsContent value="details">
               {showEditForm ? (

--- a/components/calendar/dialog/calendar-manage-event-drawer.tsx
+++ b/components/calendar/dialog/calendar-manage-event-drawer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 // import * as React from "react";
 
 import { Button } from "@/components/ui/button";
@@ -43,6 +43,16 @@ export default function CalendarManageEventDrawer() {
 
   const [showEditForm, setShowEditForm] = useState(false);
   const [activeTab, setActiveTab] = useState("details");
+
+  const eventType = selectedEvent?.program?.type?.toLowerCase();
+  const showStaffTab =
+    !!selectedEvent && eventType !== "game" && eventType !== "practice";
+
+  useEffect(() => {
+    if (!showStaffTab && activeTab === "staff") {
+      setActiveTab("details");
+    }
+  }, [showStaffTab, activeTab]);
 
   async function handleDelete() {
     if (!selectedEvent) return;
@@ -129,13 +139,15 @@ export default function CalendarManageEventDrawer() {
                 <Info className="h-4 w-4" />
                 Details
               </TabsTrigger>
-              <TabsTrigger
-                value="staff"
-                className="flex items-center gap-2 px-6 py-3 rounded-none bg-transparent hover:bg-muted/50 transition-all data-[state=active]:border-b-2 data-[state=active]:border-primary data-[state=active]:text-primary data-[state=active]:shadow-none"
-              >
-                <UserRound className="h-4 w-4" />
-                Staff
-              </TabsTrigger>
+              {showStaffTab && (
+                <TabsTrigger
+                  value="staff"
+                  className="flex items-center gap-2 px-6 py-3 rounded-none bg-transparent hover:bg-muted/50 transition-all data-[state=active]:border-b-2 data-[state=active]:border-primary data-[state=active]:text-primary data-[state=active]:shadow-none"
+                >
+                  <UserRound className="h-4 w-4" />
+                  Staff
+                </TabsTrigger>
+              )}
             </TabsList>
             <TabsContent value="details">
               {showEditForm ? (
@@ -226,12 +238,14 @@ export default function CalendarManageEventDrawer() {
                 </div>
               )}
             </TabsContent>
-            <TabsContent value="staff" className="mt-4">
-              <EventStaffTab
-                event={selectedEvent}
-                onStaffChange={handleStaffUpdated}
-              />
-            </TabsContent>
+            {showStaffTab && (
+              <TabsContent value="staff" className="mt-4">
+                <EventStaffTab
+                  event={selectedEvent}
+                  onStaffChange={handleStaffUpdated}
+                />
+              </TabsContent>
+            )}
           </Tabs>
         </div>
       )}

--- a/components/calendar/event/EventStaffTab.tsx
+++ b/components/calendar/event/EventStaffTab.tsx
@@ -1,0 +1,441 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Separator } from "@/components/ui/separator";
+import { revalidateEvents } from "@/actions/serverActions";
+import { useToast } from "@/hooks/use-toast";
+import { useUser } from "@/contexts/UserContext";
+import { getAllStaffs } from "@/services/staff";
+import {
+  assignStaffToEvent,
+  getEvent,
+  unassignStaffFromEvent,
+} from "@/services/events";
+import { CalendarEvent } from "@/types/calendar";
+import { EventStaffMember as EventStaffDto } from "@/types/events";
+import { User } from "@/types/user";
+
+type CalendarStaffMember = CalendarEvent["staff"][number];
+
+interface EventStaffTabProps {
+  event: CalendarEvent;
+  onStaffChange?: (staff: CalendarEvent["staff"]) => void;
+}
+
+function mapUserToEventStaff(user: User): CalendarStaffMember {
+  const [firstName, ...rest] = (user.Name || "").trim().split(/\s+/);
+  const lastName = rest.join(" ");
+
+  return {
+    id: user.ID,
+    email: user.Email ?? "",
+    firstName: firstName || "",
+    lastName: lastName || "",
+    phone: user.Phone ?? "",
+    gender: "",
+    roleName: user.StaffInfo?.Role ?? "",
+  };
+}
+
+function mapEventStaffToCalendarStaff(
+  staff: EventStaffDto
+): CalendarStaffMember {
+  return {
+    id: staff.id,
+    email: staff.email ?? "",
+    firstName: staff.first_name,
+    lastName: staff.last_name,
+    phone: staff.phone ?? "",
+    gender: staff.gender ?? "",
+    roleName: staff.role_name ?? "",
+  };
+}
+
+function getFullName(staff: CalendarStaffMember): string {
+  return [staff.firstName, staff.lastName].filter(Boolean).join(" ").trim();
+}
+
+function formatRole(role: string): string {
+  if (!role) return "Staff";
+  return role
+    .split("_")
+    .filter(Boolean)
+    .map((part) => part.charAt(0) + part.slice(1).toLowerCase())
+    .join(" ");
+}
+
+function sortStaffByName(staff: CalendarStaffMember[]): CalendarStaffMember[] {
+  return [...staff].sort((a, b) =>
+    getFullName(a).localeCompare(getFullName(b), undefined, {
+      sensitivity: "base",
+    })
+  );
+}
+
+function areStaffListsEqual(
+  first: CalendarStaffMember[],
+  second: CalendarStaffMember[]
+): boolean {
+  if (first.length !== second.length) {
+    return false;
+  }
+
+  const sortById = (list: CalendarStaffMember[]) =>
+    [...list].sort((staffA, staffB) => staffA.id.localeCompare(staffB.id));
+
+  const sortedFirst = sortById(first);
+  const sortedSecond = sortById(second);
+
+  return sortedFirst.every((staffMember, index) => {
+    const comparisonTarget = sortedSecond[index];
+    return (
+      staffMember.id === comparisonTarget.id &&
+      staffMember.email === comparisonTarget.email &&
+      staffMember.firstName === comparisonTarget.firstName &&
+      staffMember.lastName === comparisonTarget.lastName &&
+      staffMember.phone === comparisonTarget.phone &&
+      staffMember.gender === comparisonTarget.gender &&
+      staffMember.roleName === comparisonTarget.roleName
+    );
+  });
+}
+
+export default function EventStaffTab({
+  event,
+  onStaffChange,
+}: EventStaffTabProps) {
+  const { toast } = useToast();
+  const { user } = useUser();
+
+  const [assignedStaff, setAssignedStaff] = useState<CalendarEvent["staff"]>(
+    event.staff ?? []
+  );
+  const [availableStaff, setAvailableStaff] = useState<CalendarEvent["staff"]>(
+    []
+  );
+  const [searchTerm, setSearchTerm] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [pendingStaffId, setPendingStaffId] = useState<string | null>(null);
+
+  const skipNextFetchRef = useRef(false);
+
+  const refreshEventStaff = useCallback(
+    async (options?: { showErrorToast?: boolean }) => {
+      if (!user?.Jwt) {
+        return;
+      }
+
+      try {
+        const eventDetails = await getEvent(event.id, user.Jwt);
+        const fetchedStaff =
+          eventDetails.staff?.map(mapEventStaffToCalendarStaff) ?? [];
+        const normalizedStaff = sortStaffByName(fetchedStaff);
+
+        let didUpdate = false;
+        setAssignedStaff((currentStaff) => {
+          if (areStaffListsEqual(currentStaff, normalizedStaff)) {
+            return currentStaff;
+          }
+          didUpdate = true;
+          return normalizedStaff;
+        });
+
+        if (didUpdate) {
+          onStaffChange?.(normalizedStaff);
+        }
+      } catch (error) {
+        console.error("Failed to fetch event staff:", error);
+        if (options?.showErrorToast) {
+          toast({
+            status: "error",
+            description: "Unable to refresh event staff.",
+            variant: "destructive",
+          });
+        }
+      }
+    },
+    [event.id, onStaffChange, toast, user?.Jwt]
+  );
+
+  useEffect(() => {
+    setAssignedStaff(event.staff ?? []);
+  }, [event]);
+
+  useEffect(() => {
+    void refreshEventStaff();
+  }, [refreshEventStaff]);
+
+  useEffect(() => {
+    setSearchTerm("");
+  }, [event.id]);
+
+  useEffect(() => {
+    if (skipNextFetchRef.current) {
+      skipNextFetchRef.current = false;
+      return;
+    }
+
+    let isMounted = true;
+
+    const loadAvailableStaff = async () => {
+      setIsLoading(true);
+      try {
+        const staffList = await getAllStaffs();
+        if (!isMounted) return;
+
+        const assignedIds = new Set(assignedStaff.map((staff) => staff.id));
+
+        const mappedStaff = staffList
+          .filter((staff) => !assignedIds.has(staff.ID))
+          .map(mapUserToEventStaff);
+
+        setAvailableStaff(sortStaffByName(mappedStaff));
+      } catch (error) {
+        if (isMounted) {
+          toast({
+            status: "error",
+            description: "Unable to load available staff.",
+            variant: "destructive",
+          });
+        }
+      } finally {
+        if (isMounted) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    void loadAvailableStaff();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [event.id, assignedStaff, toast]);
+
+  const filteredAvailableStaff = useMemo(() => {
+    const normalizedQuery = searchTerm.trim().toLowerCase();
+    if (!normalizedQuery) {
+      return availableStaff;
+    }
+
+    return availableStaff.filter((staff) => {
+      const name = getFullName(staff).toLowerCase();
+      return (
+        name.includes(normalizedQuery) ||
+        staff.email.toLowerCase().includes(normalizedQuery) ||
+        staff.roleName.toLowerCase().includes(normalizedQuery)
+      );
+    });
+  }, [availableStaff, searchTerm]);
+
+  const handleAssign = async (staffMember: CalendarStaffMember) => {
+    if (!user?.Jwt) {
+      toast({
+        status: "error",
+        description: "You must be signed in to modify staff.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    skipNextFetchRef.current = true;
+
+    const previousAssigned = assignedStaff;
+    const previousAvailable = availableStaff;
+    const updatedAssigned = [...assignedStaff, staffMember];
+    const updatedAvailable = availableStaff.filter(
+      (staff) => staff.id !== staffMember.id
+    );
+
+    setAssignedStaff(updatedAssigned);
+    setAvailableStaff(updatedAvailable);
+    setPendingStaffId(staffMember.id);
+
+    try {
+      await assignStaffToEvent(event.id, staffMember.id, user.Jwt);
+      try {
+        await revalidateEvents();
+      } catch (revalidateError) {
+        console.error(
+          "Failed to revalidate events after assigning staff:",
+          revalidateError
+        );
+      }
+      onStaffChange?.(updatedAssigned);
+      void refreshEventStaff({ showErrorToast: true });
+    } catch (error) {
+      setAssignedStaff(previousAssigned);
+      setAvailableStaff(previousAvailable);
+      toast({
+        status: "error",
+        description:
+          error instanceof Error
+            ? error.message
+            : "Failed to assign staff member to the event.",
+        variant: "destructive",
+      });
+    } finally {
+      setPendingStaffId(null);
+    }
+  };
+
+  const handleUnassign = async (staffMember: CalendarStaffMember) => {
+    if (!user?.Jwt) {
+      toast({
+        status: "error",
+        description: "You must be signed in to modify staff.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    skipNextFetchRef.current = true;
+
+    const previousAssigned = assignedStaff;
+    const previousAvailable = availableStaff;
+    const updatedAssigned = assignedStaff.filter(
+      (staff) => staff.id !== staffMember.id
+    );
+    const updatedAvailable = sortStaffByName([...availableStaff, staffMember]);
+
+    setAssignedStaff(updatedAssigned);
+    setAvailableStaff(updatedAvailable);
+    setPendingStaffId(staffMember.id);
+
+    try {
+      await unassignStaffFromEvent(event.id, staffMember.id, user.Jwt);
+      try {
+        await revalidateEvents();
+      } catch (revalidateError) {
+        console.error(
+          "Failed to revalidate events after unassigning staff:",
+          revalidateError
+        );
+      }
+      onStaffChange?.(updatedAssigned);
+      void refreshEventStaff({ showErrorToast: true });
+    } catch (error) {
+      setAssignedStaff(previousAssigned);
+      setAvailableStaff(previousAvailable);
+      toast({
+        status: "error",
+        description:
+          error instanceof Error
+            ? error.message
+            : "Failed to remove staff member from the event.",
+        variant: "destructive",
+      });
+    } finally {
+      setPendingStaffId(null);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-3">
+        <div>
+          <h3 className="text-lg font-semibold">Assigned Staff</h3>
+          <p className="text-sm text-muted-foreground">
+            Manage the staff members assigned to this event.
+          </p>
+        </div>
+        {assignedStaff.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No staff members are currently assigned.
+          </p>
+        ) : (
+          <ul className="space-y-2">
+            {assignedStaff.map((staff) => {
+              const displayName = getFullName(staff) || staff.email || "Staff";
+              return (
+                <li
+                  key={staff.id}
+                  className="flex items-center justify-between rounded-md border px-3 py-2"
+                >
+                  <div className="space-y-1">
+                    <p className="text-sm font-medium leading-none">
+                      {displayName}
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      {formatRole(staff.roleName)}
+                      {staff.email ? ` • ${staff.email}` : ""}
+                    </p>
+                  </div>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => void handleUnassign(staff)}
+                    disabled={pendingStaffId === staff.id}
+                  >
+                    Remove
+                  </Button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+
+      <Separator />
+
+      <div className="space-y-4">
+        <div>
+          <h3 className="text-lg font-semibold">Available Staff</h3>
+          <p className="text-sm text-muted-foreground">
+            Search for staff members to add to this event.
+          </p>
+        </div>
+        <Input
+          value={searchTerm}
+          onChange={(event) => setSearchTerm(event.target.value)}
+          placeholder="Search by name, role, or email"
+        />
+        <ScrollArea className="h-64 rounded-md border">
+          <div className="p-3 space-y-2">
+            {isLoading ? (
+              <p className="text-sm text-muted-foreground">Loading staff…</p>
+            ) : filteredAvailableStaff.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                {searchTerm
+                  ? "No staff members match your search."
+                  : "No additional staff members available."}
+              </p>
+            ) : (
+              filteredAvailableStaff.map((staff) => {
+                const displayName =
+                  getFullName(staff) || staff.email || "Staff";
+                return (
+                  <div
+                    key={staff.id}
+                    className="flex items-center justify-between rounded-md bg-muted/60 px-3 py-2"
+                  >
+                    <div className="space-y-1">
+                      <p className="text-sm font-medium leading-none">
+                        {displayName}
+                      </p>
+                      <p className="text-xs text-muted-foreground">
+                        {formatRole(staff.roleName)}
+                        {staff.email ? ` • ${staff.email}` : ""}
+                      </p>
+                    </div>
+                    <Button
+                      size="sm"
+                      onClick={() => void handleAssign(staff)}
+                      disabled={pendingStaffId === staff.id}
+                    >
+                      Add
+                    </Button>
+                  </div>
+                );
+              })
+            )}
+          </div>
+        </ScrollArea>
+      </div>
+    </div>
+  );
+}

--- a/types/events.ts
+++ b/types/events.ts
@@ -19,11 +19,16 @@ export interface Event {
   updated_by: Person;
   start_at: Date;
   end_at: Date;
+  staff?: EventStaffMember[];
   customers: EventParticipant[];
 }
 
 export interface EventParticipant extends Person {
   has_cancelled_enrollment: boolean;
+}
+
+export interface EventStaffMember extends Person {
+  role_name: string;
 }
 
 export interface Person {


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
- Changed manage event drawer 
- Created Event staff tab
- Changed event service
- Changed event type

---

# 🧠 Reason for Changes

<!-- Explain why this change was necessary -->
- Changed manage event drawer: The manage-event drawer now wraps its content in a Details/Staff tab set and syncs state updates from staff edits so users can access the new staffing workflow without losing the existing event view.
- Created Event staff tab: The new EventStaffTab component handles loading, searching, and optimistically assigning or removing staff with toast feedback and calendar revalidation, giving the UI a dedicated place to manage event staffing.
- Changed event service: The events service gained assign/unassign helpers and richer single-event parsing so the frontend can call the staff assignment endpoints and receive the staff list in event responses.
- Changed event type: The Event type now includes typed staff member details to accurately represent the staff array returned by the backend and consumed by the new tab.
---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [X] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [ ] Backend APIs tested via Postman
- [X] No console errors (Frontend)
- [ ] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---


# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
- https://trello.com/c/hJ3Z11UE/332-assign-staff-to-events

---


