### PR TITLE
[Chore] Fixed membership plan POST / PUT

### DIFF
--- a/components/memberships/infoTabs/plans/Plans.tsx
+++ b/components/memberships/infoTabs/plans/Plans.tsx
@@ -334,7 +334,7 @@ export default function PlansTab({ membershipId }: { membershipId: string }) {
   };
 
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-2 gap-3">
       {plans.map((plan) => {
         const isActive = toggledPlanId === plan.id;
         if (isActive) {

--- a/components/memberships/infoTabs/plans/Plans.tsx
+++ b/components/memberships/infoTabs/plans/Plans.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -26,20 +27,38 @@ export default function PlansTab({ membershipId }: { membershipId: string }) {
 
   // states
   const [toggledPlanId, setToggledPlanId] = useState<string | null>(null);
-  const [editablePlans, setEditablePlans] = useState<any>({});
-  const [newperiod, setnewperiod] = useState<any>();
-  const [newname, setnewname] = useState<string>("");
-  const [newprice, setnewprice] = useState<string>("");
-  const [newjoiningfee, setnewjoiningfee] = useState<string>("");
-  const [newplantoggle, setnewplantoggle] = useState(false);
+  const [editablePlans, setEditablePlans] = useState<
+    Record<string, Record<string, any>>
+  >({});
+  const [newPeriod, setNewPeriod] = useState<string>("");
+  const [newName, setNewName] = useState<string>("");
+  const [newStripePriceId, setNewStripePriceId] = useState<string>("");
+  const [newStripeJoiningFeeId, setNewStripeJoiningFeeId] =
+    useState<string>("");
+  const [newPlanToggle, setNewPlanToggle] = useState(false);
+  const [newUsingCredits, setNewUsingCredits] = useState(false);
+  const [newCreditAllocation, setNewCreditAllocation] = useState<string>("");
+  const [newWeeklyCreditLimit, setNewWeeklyCreditLimit] = useState<string>("");
 
   const [plans, setPlans] = useState<MembershipPlan[]>([]);
 
-  const formatPrice = (price: number) =>
-    new Intl.NumberFormat("en-US", {
-      style: "currency",
-      currency: "CAD",
-    }).format(price);
+  const parseOptionalNumber = (value: unknown) => {
+    if (value === undefined || value === null) {
+      return undefined;
+    }
+    if (typeof value === "string") {
+      const trimmed = value.trim();
+      if (trimmed === "") {
+        return undefined;
+      }
+      const numericValue = Number(trimmed);
+      return Number.isNaN(numericValue) ? undefined : numericValue;
+    }
+    if (typeof value === "number") {
+      return Number.isNaN(value) ? undefined : value;
+    }
+    return undefined;
+  };
 
   const fetchPlans = async () => {
     try {
@@ -68,17 +87,38 @@ export default function PlansTab({ membershipId }: { membershipId: string }) {
     if (toggledPlanId === planId) {
       setToggledPlanId(null);
     } else {
+      const plan = plans.find((p) => p.id === planId);
+      if (!plan) return;
       setToggledPlanId(planId);
-      setEditablePlans((prev: any) => ({
+      setEditablePlans((prev) => ({
         ...prev,
-        [planId]: plans.find((p) => p.id === planId),
+        [planId]: {
+          ...plan,
+          amt_periods: plan.amt_periods?.toString() ?? "",
+          stripe_price_id: plan.stripe_price_id ?? "",
+          stripe_joining_fees_id: plan.stripe_joining_fees_id ?? "",
+          credit_allocation:
+            plan.credit_allocation != null
+              ? plan.credit_allocation.toString()
+              : "",
+          weekly_credit_limit:
+            plan.weekly_credit_limit != null
+              ? plan.weekly_credit_limit.toString()
+              : "",
+          usingCredits:
+            plan.credit_allocation != null || plan.weekly_credit_limit != null,
+        },
       }));
     }
   };
 
   // Change values in editable plan
-  const handleInputChange = (planId: string, field: string, value: string) => {
-    setEditablePlans((prev: any) => ({
+  const handleInputChange = (
+    planId: string,
+    field: string,
+    value: string | number | boolean
+  ) => {
+    setEditablePlans((prev) => ({
       ...prev,
       [planId]: {
         ...prev[planId],
@@ -87,17 +127,53 @@ export default function PlansTab({ membershipId }: { membershipId: string }) {
     }));
   };
 
+  const handlePlanCreditsToggle = (planId: string, enabled: boolean) => {
+    setEditablePlans((prev) => {
+      const currentPlan = prev[planId] || {};
+      return {
+        ...prev,
+        [planId]: {
+          ...currentPlan,
+          usingCredits: enabled,
+          credit_allocation: enabled
+            ? (currentPlan.credit_allocation ?? "")
+            : "",
+          weekly_credit_limit: enabled
+            ? (currentPlan.weekly_credit_limit ?? "")
+            : "",
+        },
+      };
+    });
+  };
+
   // toggle between adding new plans
-  const togglenewplan = () => {
-    if (newplantoggle == false) {
-      setnewplantoggle(true);
-    } else setnewplantoggle(false);
+  const toggleNewPlan = () => {
+    setNewPlanToggle((prev) => {
+      if (prev) {
+        setNewName("");
+        setNewStripePriceId("");
+        setNewStripeJoiningFeeId("");
+        setNewPeriod("");
+        setNewUsingCredits(false);
+        setNewCreditAllocation("");
+        setNewWeeklyCreditLimit("");
+      }
+      return !prev;
+    });
+  };
+
+  const handleNewPlanCreditToggle = (enabled: boolean) => {
+    setNewUsingCredits(enabled);
+    if (!enabled) {
+      setNewCreditAllocation("");
+      setNewWeeklyCreditLimit("");
+    }
   };
 
   // add new plan
-  const addnewplan = async () => {
+  const addNewPlan = async () => {
     // verify no null enters
-    if (!newname || !newprice || !newperiod) {
+    if (!newName || !newStripePriceId || !newPeriod) {
       toast({
         status: "error",
         description:
@@ -108,7 +184,7 @@ export default function PlansTab({ membershipId }: { membershipId: string }) {
     }
 
     // ensure period is a number
-    const parsedPeriod = parseInt(newperiod, 10);
+    const parsedPeriod = parseInt(newPeriod, 10);
 
     if (isNaN(parsedPeriod) || parsedPeriod <= 0) {
       toast({
@@ -128,10 +204,18 @@ export default function PlansTab({ membershipId }: { membershipId: string }) {
         },
         body: JSON.stringify({
           membership_id: membershipId,
-          name: newname,
-          stripe_price_id: newprice,
-          stripe_joining_fees_id: newjoiningfee ? newjoiningfee : undefined,
+          name: newName,
+          stripe_price_id: newStripePriceId,
+          stripe_joining_fees_id: newStripeJoiningFeeId
+            ? newStripeJoiningFeeId
+            : undefined,
           amt_periods: parsedPeriod,
+          ...(newUsingCredits
+            ? {
+                credit_allocation: parseOptionalNumber(newCreditAllocation),
+                weekly_credit_limit: parseOptionalNumber(newWeeklyCreditLimit),
+              }
+            : {}),
         }),
       });
       if (!response.ok) {
@@ -146,11 +230,14 @@ export default function PlansTab({ membershipId }: { membershipId: string }) {
           description: "Plan created successfully",
         });
         refreshPlans();
-        setnewname("");
-        setnewprice("");
-        setnewjoiningfee("");
-        setnewperiod("");
-        setnewplantoggle(false);
+        setNewName("");
+        setNewStripePriceId("");
+        setNewStripeJoiningFeeId("");
+        setNewPeriod("");
+        setNewCreditAllocation("");
+        setNewWeeklyCreditLimit("");
+        setNewUsingCredits(false);
+        setNewPlanToggle(false);
       }
     } catch (err) {
       console.error("Failed to save plan", err);
@@ -162,7 +249,7 @@ export default function PlansTab({ membershipId }: { membershipId: string }) {
     const updatedPlan = editablePlans[planId];
 
     // ensure period is a number
-    const parsedPeriod = parseInt(updatedPlan.amt_periods, 10);
+    const parsedPeriod = parseInt(String(updatedPlan.amt_periods), 10);
     if (isNaN(parsedPeriod) || parsedPeriod <= 0) {
       toast({
         status: "error",
@@ -184,11 +271,21 @@ export default function PlansTab({ membershipId }: { membershipId: string }) {
           body: JSON.stringify({
             membership_id: membershipId,
             name: updatedPlan.name,
-            stripe_price_id: updatedPlan.price,
-            stripe_joining_fees_id: updatedPlan.joining_fee
-              ? updatedPlan.joining_fee
+            stripe_price_id: updatedPlan.stripe_price_id,
+            stripe_joining_fees_id: updatedPlan.stripe_joining_fees_id
+              ? updatedPlan.stripe_joining_fees_id
               : undefined,
             amt_periods: parsedPeriod,
+            ...(updatedPlan.usingCredits
+              ? {
+                  credit_allocation: parseOptionalNumber(
+                    updatedPlan.credit_allocation
+                  ),
+                  weekly_credit_limit: parseOptionalNumber(
+                    updatedPlan.weekly_credit_limit
+                  ),
+                }
+              : {}),
           }),
         }
       );
@@ -252,21 +349,34 @@ export default function PlansTab({ membershipId }: { membershipId: string }) {
                   onClick={() => handleTogglePlan(plan.id)}
                 >
                   <h1>{plan.name}</h1>
-                  <div className="flex">
+                  <div className="flex flex-wrap gap-x-2">
                     <h1 className="font-semibold text-sm pt-1 text-stone-500 pr-1">
-                      Price
+                      Stripe price id
                     </h1>
                     <h1 className="text-stone-500 font-medium text-sm pt-1 pr-1">
-                      {formatPrice(plan.price ?? 0)}
+                      {plan.stripe_price_id || "—"}
                     </h1>
                     <h1 className="text-stone-500 font-semibold text-sm pt-1">
                       • Every {plan.amt_periods} Months
                     </h1>
                   </div>
+                  {(plan.credit_allocation != null ||
+                    plan.weekly_credit_limit != null) && (
+                    <div className="flex flex-col text-xs text-stone-500 pt-1 space-y-0.5">
+                      {plan.credit_allocation != null && (
+                        <span>Credits allocated: {plan.credit_allocation}</span>
+                      )}
+                      {plan.weekly_credit_limit != null && (
+                        <span>
+                          Weekly credit limit: {plan.weekly_credit_limit}
+                        </span>
+                      )}
+                    </div>
+                  )}
                 </div>
                 <div className="pt-2 flex">
                   <div className="w-full pr-5">
-                    <Label className="w-full"> Plan Name </Label>
+                    <Label className="w-full">Name</Label>
                     <Input
                       className="w-full mt-1"
                       onChange={(e) =>
@@ -278,37 +388,43 @@ export default function PlansTab({ membershipId }: { membershipId: string }) {
                     />
                   </div>
                   <div className="w-full pl-1 ">
-                    <Label className="w-full"> Price </Label>
+                    <Label className="w-full">Stripe price id</Label>
                     <Input
                       className="w-full mt-1"
                       onChange={(e) =>
-                        handleInputChange(plan.id, "price", e.target.value)
+                        handleInputChange(
+                          plan.id,
+                          "stripe_price_id",
+                          e.target.value
+                        )
                       }
-                      value={editablePlans[plan.id]?.price || ""}
-                      placeholder={plan.price?.toString()}
+                      value={editablePlans[plan.id]?.stripe_price_id || ""}
+                      placeholder={plan.stripe_price_id}
                       onClick={(e) => e.stopPropagation()}
                     />
                   </div>
                 </div>
                 <div className="pt-3 flex">
                   <div className="w-full pr-5">
-                    <Label className="w-full">Joining Fee</Label>
+                    <Label className="w-full">Stripe join fee</Label>
                     <Input
                       className="w-full mt-1"
                       onChange={(e) =>
                         handleInputChange(
                           plan.id,
-                          "joining_fee",
+                          "stripe_joining_fees_id",
                           e.target.value
                         )
                       }
-                      value={editablePlans[plan.id]?.joining_fee || ""}
-                      placeholder={plan.joining_fee?.toString()}
+                      value={
+                        editablePlans[plan.id]?.stripe_joining_fees_id || ""
+                      }
+                      placeholder={plan.stripe_joining_fees_id}
                       onClick={(e) => e.stopPropagation()}
                     />
                   </div>
                   <div className="w-full pl-1 ">
-                    <Label className="w-full"> Period </Label>
+                    <Label className="w-full">Period</Label>
                     <Input
                       className="w-full mt-1"
                       onChange={(e) =>
@@ -324,6 +440,61 @@ export default function PlansTab({ membershipId }: { membershipId: string }) {
                     />
                   </div>
                 </div>
+                <div className="pt-3 flex items-center space-x-2">
+                  <Checkbox
+                    id={`plan-${plan.id}-using-credits`}
+                    checked={Boolean(editablePlans[plan.id]?.usingCredits)}
+                    onCheckedChange={(checked) =>
+                      handlePlanCreditsToggle(plan.id, checked === true)
+                    }
+                    onClick={(e) => e.stopPropagation()}
+                  />
+                  <Label
+                    htmlFor={`plan-${plan.id}-using-credits`}
+                    className="text-sm font-medium cursor-pointer"
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    Using credits
+                  </Label>
+                </div>
+                {editablePlans[plan.id]?.usingCredits && (
+                  <div className="pt-3 flex">
+                    <div className="w-full pr-5">
+                      <Label className="w-full">Credit allocation</Label>
+                      <Input
+                        className="w-full mt-1"
+                        onChange={(e) =>
+                          handleInputChange(
+                            plan.id,
+                            "credit_allocation",
+                            e.target.value
+                          )
+                        }
+                        value={editablePlans[plan.id]?.credit_allocation || ""}
+                        placeholder="0"
+                        onClick={(e) => e.stopPropagation()}
+                      />
+                    </div>
+                    <div className="w-full pl-1 ">
+                      <Label className="w-full">Weekly credit limit</Label>
+                      <Input
+                        className="w-full mt-1"
+                        onChange={(e) =>
+                          handleInputChange(
+                            plan.id,
+                            "weekly_credit_limit",
+                            e.target.value
+                          )
+                        }
+                        value={
+                          editablePlans[plan.id]?.weekly_credit_limit || ""
+                        }
+                        placeholder="0"
+                        onClick={(e) => e.stopPropagation()}
+                      />
+                    </div>
+                  </div>
+                )}
                 <div className="flex pt-5 gap-3">
                   <div
                     className="p-1 pl-5 pr-5 bg-green-600 hover:bg-green-700 rounded cursor-pointer"
@@ -378,79 +549,133 @@ export default function PlansTab({ membershipId }: { membershipId: string }) {
             >
               <div className="p-2">
                 <h1>{plan.name}</h1>
-                <div className="flex">
+                <div className="flex flex-wrap gap-x-2">
                   <h1 className="font-semibold text-sm pt-1 text-stone-500 pr-1">
-                    Price
+                    Stripe price id
                   </h1>
                   <h1 className="text-stone-500 font-medium text-sm pt-1 pr-1">
-                    {formatPrice(plan.price ?? 0)}
+                    {plan.stripe_price_id || "—"}
                   </h1>
                   <h1 className="text-stone-500 font-semibold text-sm pt-1">
                     • Every {plan.amt_periods} Months
                   </h1>
                 </div>
+                {(plan.credit_allocation != null ||
+                  plan.weekly_credit_limit != null) && (
+                  <div className="flex flex-col text-xs text-stone-500 pt-1 space-y-0.5">
+                    {plan.credit_allocation != null && (
+                      <span>Credits allocated: {plan.credit_allocation}</span>
+                    )}
+                    {plan.weekly_credit_limit != null && (
+                      <span>
+                        Weekly credit limit: {plan.weekly_credit_limit}
+                      </span>
+                    )}
+                  </div>
+                )}
               </div>
             </div>
           );
         }
       })}
 
-      {newplantoggle ? (
+      {newPlanToggle ? (
         <div className="w-full p-3 rounded-lg border-orange-500 border">
           <div className="p-2">
-            <div className="cursor-pointer" onClick={togglenewplan}>
+            <div className="cursor-pointer" onClick={toggleNewPlan}>
               <h1> Add a new plan </h1>
             </div>
             <div className="pt-2 flex">
               <div className="w-full pr-5">
-                <Label className="w-full"> Plan Name </Label>
+                <Label className="w-full">Name</Label>
                 <Input
                   className="w-full mt-1"
-                  value={newname ?? ""}
-                  onChange={(e) => setnewname(e.target.value)}
+                  value={newName}
+                  onChange={(e) => setNewName(e.target.value)}
                   placeholder="name of plan"
                   onClick={(e) => e.stopPropagation()}
                 />
               </div>
               <div className="w-full pl-1 ">
-                <Label className="w-full">Price</Label>
+                <Label className="w-full">Stripe price id</Label>
                 <Input
                   className="w-full mt-1"
-                  value={newprice ?? ""}
-                  onChange={(e) => setnewprice(e.target.value)}
-                  placeholder="0"
+                  value={newStripePriceId}
+                  onChange={(e) => setNewStripePriceId(e.target.value)}
+                  placeholder="price_..."
                   onClick={(e) => e.stopPropagation()}
                 />
               </div>
             </div>
             <div className="pt-3 flex">
               <div className="w-full pr-5">
-                <Label className="w-full">Joining Fee</Label>
+                <Label className="w-full">Stripe join fee</Label>
                 <Input
                   className="w-full mt-1"
-                  value={newjoiningfee ?? ""}
-                  onChange={(e) => setnewjoiningfee(e.target.value)}
-                  placeholder="0"
+                  value={newStripeJoiningFeeId}
+                  onChange={(e) => setNewStripeJoiningFeeId(e.target.value)}
+                  placeholder="price_..."
                   onClick={(e) => e.stopPropagation()}
                 />
               </div>
               <div className="w-full pl-1 ">
-                <Label className="w-full"> Period </Label>
+                <Label className="w-full">Period</Label>
                 <Input
                   className="w-full mt-1"
-                  value={newperiod ?? ""}
+                  value={newPeriod}
                   placeholder="1"
-                  onChange={(e) => setnewperiod(e.target.value)}
+                  onChange={(e) => setNewPeriod(e.target.value)}
                   onClick={(e) => e.stopPropagation()}
                 />
               </div>
             </div>
+            <div className="pt-3 flex items-center space-x-2">
+              <Checkbox
+                id="new-plan-using-credits"
+                checked={newUsingCredits}
+                onCheckedChange={(checked) =>
+                  handleNewPlanCreditToggle(checked === true)
+                }
+                onClick={(e) => e.stopPropagation()}
+              />
+              <Label
+                htmlFor="new-plan-using-credits"
+                className="text-sm font-medium cursor-pointer"
+                onClick={(e) => e.stopPropagation()}
+              >
+                Using credits
+              </Label>
+            </div>
+            {newUsingCredits && (
+              <div className="pt-3 flex">
+                <div className="w-full pr-5">
+                  <Label className="w-full">Credit allocation</Label>
+                  <Input
+                    className="w-full mt-1"
+                    value={newCreditAllocation}
+                    onChange={(e) => setNewCreditAllocation(e.target.value)}
+                    placeholder="0"
+                    onClick={(e) => e.stopPropagation()}
+                  />
+                </div>
+                <div className="w-full pl-1 ">
+                  <Label className="w-full">Weekly credit limit</Label>
+                  <Input
+                    className="w-full mt-1"
+                    value={newWeeklyCreditLimit}
+                    onChange={(e) => setNewWeeklyCreditLimit(e.target.value)}
+                    placeholder="0"
+                    onClick={(e) => e.stopPropagation()}
+                  />
+                </div>
+              </div>
+            )}
             <div className="flex pt-5 gap-3">
               <div
                 className="p-1 pl-5 pr-5 bg-green-600 hover:bg-green-700 rounded cursor-pointer"
                 onClick={(e) => {
-                  e.stopPropagation;
-                  addnewplan();
+                  e.stopPropagation();
+                  addNewPlan();
                 }}
               >
                 {" "}
@@ -458,7 +683,7 @@ export default function PlansTab({ membershipId }: { membershipId: string }) {
               </div>
               <div
                 className="p-1 pl-5 pr-5 bg-red-700 hover:bg-red-900 rounded cursor-pointer"
-                onClick={togglenewplan}
+                onClick={toggleNewPlan}
               >
                 {" "}
                 Cancel{" "}
@@ -469,7 +694,7 @@ export default function PlansTab({ membershipId }: { membershipId: string }) {
       ) : (
         <div
           className="p-7 w-full h-12 cursor-pointer hover:text-stone-300 flex items-center justify-center rounded-lg border border-dotted"
-          onClick={togglenewplan}
+          onClick={toggleNewPlan}
         >
           <h1 className="text-sm">Add New Plan + </h1>
         </div>

--- a/services/membershipPlan.ts
+++ b/services/membershipPlan.ts
@@ -18,17 +18,6 @@ export async function getPlansForMembership(
 
     const data: MembershipPlanPlanResponse[] = await res.json();
 
-    // Ensure numeric values for price-related fields to avoid NaN when formatting
-    const parseNumber = (value: unknown): number => {
-      if (typeof value === "number") return value;
-      if (typeof value === "string") {
-        const cleaned = value.replace(/[^0-9.-]+/g, "");
-        const parsed = parseFloat(cleaned);
-        return isNaN(parsed) ? 0 : parsed;
-      }
-      return 0;
-    };
-
     return data.map((plan) => ({
       id: plan.id!,
       membership_id: plan.membership_id!,
@@ -36,8 +25,8 @@ export async function getPlansForMembership(
       stripe_price_id: plan.stripe_price_id || "",
       stripe_joining_fees_id: plan.stripe_joining_fees_id || "",
       amt_periods: plan.amt_periods || 0,
-      price: parseNumber((plan as any).price),
-      joining_fee: parseNumber((plan as any).joining_fee),
+      credit_allocation: (plan as any).credit_allocation ?? null,
+      weekly_credit_limit: (plan as any).weekly_credit_limit ?? null,
     }));
   } catch (err) {
     console.error("🔥 Error loading membership plans:", err);

--- a/types/membership.ts
+++ b/types/membership.ts
@@ -13,8 +13,8 @@ export interface MembershipPlan {
   stripe_price_id: string;
   stripe_joining_fees_id?: string;
   amt_periods: number;
-  price?: number;
-  joining_fee?: number;
+  credit_allocation?: number | null;
+  weekly_credit_limit?: number | null;
 }
 
 export interface MembershipPlanRequestDto {
@@ -23,4 +23,6 @@ export interface MembershipPlanRequestDto {
   stripe_price_id: string;
   stripe_joining_fees_id?: string;
   amt_periods: number;
+  credit_allocation?: number;
+  weekly_credit_limit?: number;
 }


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
- Changed membership info tabs
- Changed membership plan service 
- Changed membership type


---

# 🧠 Reason for Changes

<!-- Explain why this change was necessary -->
- The membership info tab needed to capture Stripe price/join IDs and optional credit settings directly in the UI state so labels, summaries, and POST/PUT payloads reflect the identifiers and only include credit data when the “Using credits” controls are active.

- The membership plan service needed to forward the backend’s Stripe and credit fields verbatim instead of synthesizing price values, ensuring clients receive the exact identifiers and optional credit metadata returned by the API.

- The shared membership types had to expose optional credit allocation and weekly limit fields (while centering on Stripe identifiers) so downstream consumers can work with the newly surfaced plan data safely.
---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [X] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [ ] Backend APIs tested via Postman
- [X] No console errors (Frontend)
- [ ] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---



# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
- https://trello.com/c/RhHcbuP1/285-fix-adding-membership-plan-price

---



