### PR TITLE
[Feature] Added Barber Availability to the Barber page 

### DIFF
--- a/app/(dashboard)/manage/barbershop/availability/page.tsx
+++ b/app/(dashboard)/manage/barbershop/availability/page.tsx
@@ -1,0 +1,5 @@
+import ManageBarberAvailability from "@/components/Barbershop/ManageBarberAvailability";
+
+export default function ManageBarberAvailabilityPage() {
+  return <ManageBarberAvailability />;
+}

--- a/app/api/docs/swagger.json
+++ b/app/api/docs/swagger.json
@@ -2754,6 +2754,326 @@
         }
       }
     },
+    "/haircuts/barbers/me/availability": {
+      "get": {
+        "security": [
+          {
+            "Bearer": []
+          }
+        ],
+        "description": "Get all availability records for the authenticated barber",
+        "consumes": ["application/json"],
+        "produces": ["application/json"],
+        "tags": ["barber-availability"],
+        "summary": "Get my availability schedule",
+        "responses": {
+          "200": {
+            "description": "Barber availability schedule",
+            "schema": {
+              "$ref": "#/definitions/haircut_event.WeeklyAvailabilityResponseDto"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          }
+        }
+      },
+      "post": {
+        "security": [
+          {
+            "Bearer": []
+          }
+        ],
+        "description": "Set working hours for a specific day of the week",
+        "consumes": ["application/json"],
+        "produces": ["application/json"],
+        "tags": ["barber-availability"],
+        "summary": "Set availability for a day",
+        "parameters": [
+          {
+            "description": "Availability details",
+            "name": "availability",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/haircut_event.SetAvailabilityDto"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Availability created successfully",
+            "schema": {
+              "$ref": "#/definitions/haircut_event.AvailabilityResponseDto"
+            }
+          },
+          "400": {
+            "description": "Bad Request: Invalid input",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "409": {
+            "description": "Conflict: Availability already exists",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          }
+        }
+      }
+    },
+    "/haircuts/barbers/me/availability/bulk": {
+      "post": {
+        "security": [
+          {
+            "Bearer": []
+          }
+        ],
+        "description": "Set working hours for multiple days of the week in one request",
+        "consumes": ["application/json"],
+        "produces": ["application/json"],
+        "tags": ["barber-availability"],
+        "summary": "Set availability for multiple days",
+        "parameters": [
+          {
+            "description": "Multiple availability records",
+            "name": "availability",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/haircut_event.BulkSetAvailabilityDto"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "All availability set successfully",
+            "schema": {
+              "$ref": "#/definitions/haircut_event.WeeklyAvailabilityResponseDto"
+            }
+          },
+          "400": {
+            "description": "Bad Request: Invalid input",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          }
+        }
+      }
+    },
+    "/haircuts/barbers/me/availability/{id}": {
+      "put": {
+        "security": [
+          {
+            "Bearer": []
+          }
+        ],
+        "description": "Update an existing availability record by ID",
+        "consumes": ["application/json"],
+        "produces": ["application/json"],
+        "tags": ["barber-availability"],
+        "summary": "Update availability record",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Availability ID",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "description": "Updated availability details",
+            "name": "availability",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/haircut_event.UpdateAvailabilityDto"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Availability updated successfully",
+            "schema": {
+              "$ref": "#/definitions/haircut_event.AvailabilityResponseDto"
+            }
+          },
+          "400": {
+            "description": "Bad Request: Invalid input",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "404": {
+            "description": "Not Found: Availability record not found",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          }
+        }
+      },
+      "delete": {
+        "security": [
+          {
+            "Bearer": []
+          }
+        ],
+        "description": "Delete an existing availability record by ID",
+        "consumes": ["application/json"],
+        "produces": ["application/json"],
+        "tags": ["barber-availability"],
+        "summary": "Delete availability record",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Availability ID",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content: Availability deleted successfully"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "404": {
+            "description": "Not Found: Availability record not found",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          }
+        }
+      }
+    },
+    "/haircuts/barbers/{barber_id}/availability": {
+      "get": {
+        "description": "Get available booking slots for a specific barber on a given date, considering their working hours and existing bookings.",
+        "consumes": ["application/json"],
+        "produces": ["application/json"],
+        "tags": ["haircuts"],
+        "summary": "Get available time slots for a barber",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Barber ID",
+            "name": "barber_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "example": "\"2025-09-20\"",
+            "description": "Date in YYYY-MM-DD format",
+            "name": "date",
+            "in": "query",
+            "required": true
+          },
+          {
+            "type": "integer",
+            "example": 30,
+            "description": "Service duration in minutes (default: 30)",
+            "name": "service_duration",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Available time slots",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "400": {
+            "description": "Bad Request: Invalid input",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          }
+        }
+      }
+    },
     "/haircuts/events": {
       "get": {
         "description": "Retrieve all haircut events, with optional filters by barber ID and customer ID.",
@@ -4916,6 +5236,61 @@
         }
       }
     },
+    "/secure/customers/delete-account": {
+      "delete": {
+        "security": [
+          {
+            "Bearer": []
+          }
+        ],
+        "description": "Permanently deletes the authenticated customer's account including all data from database, Firebase, and cancels Stripe subscriptions",
+        "consumes": ["application/json"],
+        "produces": ["application/json"],
+        "tags": ["customers"],
+        "summary": "Delete customer account",
+        "parameters": [
+          {
+            "description": "Account deletion confirmation",
+            "name": "confirmation",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/customer.AccountDeletionRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account deleted successfully",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "400": {
+            "description": "Bad Request: Missing confirmation",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          }
+        }
+      }
+    },
     "/secure/customers/memberships": {
       "get": {
         "security": [
@@ -5012,6 +5387,116 @@
           },
           "401": {
             "description": "Unauthorized",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          }
+        }
+      }
+    },
+    "/secure/notifications/register": {
+      "post": {
+        "security": [
+          {
+            "Bearer": []
+          }
+        ],
+        "description": "Register an Expo push token for receiving notifications",
+        "consumes": ["application/json"],
+        "produces": ["application/json"],
+        "tags": ["notifications"],
+        "summary": "Register push notification token",
+        "parameters": [
+          {
+            "description": "Push token registration details",
+            "name": "request",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/dto.RegisterPushTokenRequestDto"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Token registered successfully",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "400": {
+            "description": "Bad Request: Invalid input",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          }
+        }
+      }
+    },
+    "/secure/notifications/send": {
+      "post": {
+        "security": [
+          {
+            "Bearer": []
+          }
+        ],
+        "description": "Send a push notification to all members of a specific team",
+        "consumes": ["application/json"],
+        "produces": ["application/json"],
+        "tags": ["notifications"],
+        "summary": "Send team notification",
+        "parameters": [
+          {
+            "description": "Notification details",
+            "name": "request",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/dto.SendNotificationRequestDto"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Notification sent successfully",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "400": {
+            "description": "Bad Request: Invalid input",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
             "schema": {
               "type": "object",
               "additionalProperties": true
@@ -6306,6 +6791,16 @@
         }
       }
     },
+    "customer.AccountDeletionRequest": {
+      "type": "object",
+      "required": ["confirm_deletion"],
+      "properties": {
+        "confirm_deletion": {
+          "type": "boolean",
+          "example": true
+        }
+      }
+    },
     "customer.AthleteProfileUpdateRequestDto": {
       "type": "object",
       "properties": {
@@ -6591,6 +7086,41 @@
           "type": "string"
         },
         "tag": {
+          "type": "string"
+        }
+      }
+    },
+    "dto.RegisterPushTokenRequestDto": {
+      "type": "object",
+      "required": ["device_type", "expo_push_token"],
+      "properties": {
+        "device_type": {
+          "type": "string",
+          "enum": ["ios", "android"]
+        },
+        "expo_push_token": {
+          "type": "string"
+        }
+      }
+    },
+    "dto.SendNotificationRequestDto": {
+      "type": "object",
+      "required": ["body", "team_id", "title", "type"],
+      "properties": {
+        "body": {
+          "type": "string"
+        },
+        "data": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "team_id": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "type": {
           "type": "string"
         }
       }
@@ -6969,6 +7499,47 @@
         }
       }
     },
+    "haircut_event.AvailabilityResponseDto": {
+      "type": "object",
+      "properties": {
+        "created_at": {
+          "type": "string"
+        },
+        "day_of_week": {
+          "description": "0=Sunday, 6=Saturday",
+          "type": "integer"
+        },
+        "end_time": {
+          "description": "HH:MM format",
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "is_active": {
+          "type": "boolean"
+        },
+        "start_time": {
+          "description": "HH:MM format",
+          "type": "string"
+        },
+        "updated_at": {
+          "type": "string"
+        }
+      }
+    },
+    "haircut_event.BulkSetAvailabilityDto": {
+      "type": "object",
+      "required": ["availability"],
+      "properties": {
+        "availability": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/haircut_event.SetAvailabilityDto"
+          }
+        }
+      }
+    },
     "haircut_event.EventResponseDto": {
       "type": "object",
       "properties": {
@@ -7020,6 +7591,69 @@
         "service_name": {
           "type": "string",
           "example": "Haircut"
+        }
+      }
+    },
+    "haircut_event.SetAvailabilityDto": {
+      "type": "object",
+      "required": ["day_of_week", "end_time", "start_time"],
+      "properties": {
+        "day_of_week": {
+          "description": "0=Sunday, 6=Saturday",
+          "type": "integer",
+          "maximum": 6,
+          "minimum": 0,
+          "example": 1
+        },
+        "end_time": {
+          "description": "HH:MM format",
+          "type": "string",
+          "example": "17:00"
+        },
+        "is_active": {
+          "description": "Optional, defaults to true",
+          "type": "boolean",
+          "example": true
+        },
+        "start_time": {
+          "description": "HH:MM format",
+          "type": "string",
+          "example": "09:00"
+        }
+      }
+    },
+    "haircut_event.UpdateAvailabilityDto": {
+      "type": "object",
+      "required": ["end_time", "start_time"],
+      "properties": {
+        "end_time": {
+          "type": "string",
+          "example": "17:00"
+        },
+        "is_active": {
+          "type": "boolean",
+          "example": true
+        },
+        "start_time": {
+          "type": "string",
+          "example": "09:00"
+        }
+      }
+    },
+    "haircut_event.WeeklyAvailabilityResponseDto": {
+      "type": "object",
+      "properties": {
+        "availability": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/haircut_event.AvailabilityResponseDto"
+          }
+        },
+        "barber_id": {
+          "type": "string"
+        },
+        "barber_name": {
+          "type": "string"
         }
       }
     },
@@ -7303,10 +7937,7 @@
         "interval": {
           "type": "string"
         },
-        "joining_fee": {
-          "type": "integer"
-        },
-        "joining_fee_display": {
+        "joining_fee_price": {
           "type": "string"
         },
         "membership_id": {

--- a/components/Barbershop/AvailabilityForm.tsx
+++ b/components/Barbershop/AvailabilityForm.tsx
@@ -1,0 +1,268 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
+import { useToast } from "@/hooks/use-toast";
+import { BarberAvailabilityRecord } from "@/services/barberAvailability";
+
+type AvailabilityFormMode = "create" | "edit";
+
+export type AvailabilityFormValues = {
+  day_of_week?: number;
+  start_time: string;
+  end_time: string;
+  is_active: boolean;
+};
+
+const dayOptions = [
+  { label: "Monday", value: 1 },
+  { label: "Tuesday", value: 2 },
+  { label: "Wednesday", value: 3 },
+  { label: "Thursday", value: 4 },
+  { label: "Friday", value: 5 },
+  { label: "Saturday", value: 6 },
+  { label: "Sunday", value: 7 },
+];
+
+interface AvailabilityFormProps {
+  mode: AvailabilityFormMode;
+  onSubmit: (values: AvailabilityFormValues) => Promise<void> | void;
+  onCancel: () => void;
+  initialData?: BarberAvailabilityRecord | null;
+  isSubmitting?: boolean;
+  unavailableDays?: number[];
+  onDelete?: () => Promise<void> | void;
+  isDeleting?: boolean;
+}
+
+function normalizeTimeValue(value?: string) {
+  if (!value) return "";
+  const [hours, minutes] = value.split(":");
+  if (!hours) return value;
+  return `${hours.padStart(2, "0")}:${(minutes ?? "00").padStart(2, "0")}`;
+}
+
+function normalizeDayOfWeek(value?: number) {
+  if (typeof value !== "number") {
+    return undefined;
+  }
+
+  return value === 0 ? 7 : value;
+}
+
+export default function AvailabilityForm({
+  mode,
+  onSubmit,
+  onCancel,
+  initialData,
+  isSubmitting = false,
+  unavailableDays = [],
+  onDelete,
+  isDeleting = false,
+}: AvailabilityFormProps) {
+  const { toast } = useToast();
+  const normalizedInitialDay = normalizeDayOfWeek(initialData?.day_of_week);
+  const normalizedUnavailableDays = useMemo(
+    () =>
+      unavailableDays
+        .map(normalizeDayOfWeek)
+        .filter((value): value is number => typeof value === "number"),
+    [unavailableDays]
+  );
+  const [formValues, setFormValues] = useState<AvailabilityFormValues>({
+    day_of_week: mode === "create" ? undefined : normalizedInitialDay,
+    start_time: normalizeTimeValue(initialData?.start_time),
+    end_time: normalizeTimeValue(initialData?.end_time),
+    is_active: initialData?.is_active ?? true,
+  });
+
+  useEffect(() => {
+    setFormValues({
+      day_of_week:
+        mode === "create"
+          ? undefined
+          : normalizeDayOfWeek(initialData?.day_of_week),
+      start_time: normalizeTimeValue(initialData?.start_time),
+      end_time: normalizeTimeValue(initialData?.end_time),
+      is_active: initialData?.is_active ?? true,
+    });
+  }, [initialData, mode]);
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (mode === "create" && typeof formValues.day_of_week !== "number") {
+      toast({
+        status: "error",
+        description: "Please select a day of the week",
+      });
+      return;
+    }
+
+    if (!formValues.start_time || !formValues.end_time) {
+      toast({
+        status: "error",
+        description: "Start and end times are required",
+      });
+      return;
+    }
+
+    if (formValues.start_time >= formValues.end_time) {
+      toast({
+        status: "error",
+        description: "Start time must be before end time",
+      });
+      return;
+    }
+
+    await onSubmit(formValues);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6 pt-3">
+      {mode === "create" ? (
+        <div className="space-y-2">
+          <Label>Day of week</Label>
+          <Select
+            value={
+              typeof formValues.day_of_week === "number"
+                ? formValues.day_of_week.toString()
+                : undefined
+            }
+            onValueChange={(value) =>
+              setFormValues((previous) => ({
+                ...previous,
+                day_of_week: Number(value),
+              }))
+            }
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="Select a day" />
+            </SelectTrigger>
+            <SelectContent>
+              {dayOptions.map((day) => (
+                <SelectItem
+                  key={day.value}
+                  value={day.value.toString()}
+                  disabled={normalizedUnavailableDays.includes(day.value)}
+                >
+                  {day.label}
+                  {normalizedUnavailableDays.includes(day.value) &&
+                    " (Already set)"}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <p className="text-xs text-muted-foreground">
+            Availability is stored with Monday as 1 through Sunday as 7.
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          <Label>Day of week</Label>
+          <Input
+            value={
+              dayOptions.find(
+                (day) =>
+                  day.value === normalizeDayOfWeek(initialData?.day_of_week)
+              )?.label || ""
+            }
+            disabled
+          />
+        </div>
+      )}
+
+      <div className="space-y-2">
+        <Label>Start time</Label>
+        <Input
+          type="time"
+          value={formValues.start_time}
+          onChange={(event) =>
+            setFormValues((previous) => ({
+              ...previous,
+              start_time: event.target.value,
+            }))
+          }
+          step={300}
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label>End time</Label>
+        <Input
+          type="time"
+          value={formValues.end_time}
+          onChange={(event) =>
+            setFormValues((previous) => ({
+              ...previous,
+              end_time: event.target.value,
+            }))
+          }
+          step={300}
+        />
+      </div>
+
+      <div className="flex items-center justify-between rounded-md border p-3">
+        <div>
+          <p className="text-sm font-medium">Active</p>
+          <p className="text-xs text-muted-foreground">
+            Toggle availability on or off without deleting it
+          </p>
+        </div>
+        <Switch
+          checked={formValues.is_active}
+          onCheckedChange={(checked) =>
+            setFormValues((previous) => ({
+              ...previous,
+              is_active: checked,
+            }))
+          }
+        />
+      </div>
+
+      <div className="flex flex-col gap-3 pt-4">
+        {mode === "edit" && onDelete && (
+          <Button
+            type="button"
+            variant="destructive"
+            onClick={onDelete}
+            disabled={isSubmitting || isDeleting}
+          >
+            {isDeleting ? "Deleting…" : "Delete availability"}
+          </Button>
+        )}
+        <div className="flex items-center justify-end gap-3">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={onCancel}
+            disabled={isSubmitting || isDeleting}
+          >
+            Cancel
+          </Button>
+          <Button type="submit" disabled={isSubmitting || isDeleting}>
+            {isSubmitting
+              ? mode === "create"
+                ? "Saving…"
+                : "Updating…"
+              : mode === "create"
+                ? "Save availability"
+                : "Update availability"}
+          </Button>
+        </div>
+      </div>
+    </form>
+  );
+}
+
+export { dayOptions, normalizeDayOfWeek };

--- a/components/Barbershop/BarberPage.tsx
+++ b/components/Barbershop/BarberPage.tsx
@@ -235,6 +235,11 @@ export default function BarbershopPage({ staffs }: { staffs: User[] }) {
             Manage Barber Services
           </Link>
         </Button>
+        <Button variant="outline" asChild>
+          <Link href="/manage/barbershop/availability">
+            Manage Availability
+          </Link>
+        </Button>
       </div>
 
       {/* Stats Cards */}

--- a/components/Barbershop/ManageBarberAvailability.tsx
+++ b/components/Barbershop/ManageBarberAvailability.tsx
@@ -1,0 +1,364 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Heading } from "@/components/ui/Heading";
+import { Separator } from "@/components/ui/separator";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { useToast } from "@/hooks/use-toast";
+import { useUser } from "@/contexts/UserContext";
+import RightDrawer from "@/components/reusable/RightDrawer";
+import AvailabilityForm, {
+  AvailabilityFormValues,
+  dayOptions,
+  normalizeDayOfWeek,
+} from "./AvailabilityForm";
+import Link from "next/link";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { PlusIcon } from "lucide-react";
+import {
+  BarberAvailabilityRecord,
+  createBarberAvailability,
+  deleteBarberAvailability,
+  getMyBarberAvailability,
+  updateBarberAvailability,
+} from "@/services/barberAvailability";
+import { formatDate } from "@/lib/utils";
+
+function formatDisplayTime(time?: string) {
+  if (!time) return "--";
+  const parts = time.split(":");
+  const hour = Number(parts[0]);
+  const minute = Number(parts[1] ?? "0");
+
+  if (Number.isNaN(hour) || Number.isNaN(minute)) {
+    return time;
+  }
+
+  const date = new Date();
+  date.setHours(hour, minute, 0, 0);
+  return new Intl.DateTimeFormat("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(date);
+}
+
+const getComparableDayValue = (day: number) => {
+  const normalized = normalizeDayOfWeek(day);
+  return typeof normalized === "number" ? normalized : day;
+};
+
+export default function ManageBarberAvailability() {
+  const { toast } = useToast();
+  const { user } = useUser();
+
+  const [availability, setAvailability] = useState<BarberAvailabilityRecord[]>(
+    []
+  );
+  const [isLoading, setIsLoading] = useState(true);
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [drawerMode, setDrawerMode] = useState<"create" | "edit" | null>(null);
+  const [selectedAvailability, setSelectedAvailability] =
+    useState<BarberAvailabilityRecord | null>(null);
+  const [formSubmitting, setFormSubmitting] = useState(false);
+  const [deleteSubmitting, setDeleteSubmitting] = useState(false);
+
+  const refreshAvailability = useCallback(async () => {
+    if (!user?.Jwt) {
+      setAvailability([]);
+      setIsLoading(false);
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      const response = await getMyBarberAvailability(user.Jwt);
+      setAvailability(response.availability ?? []);
+    } catch (error) {
+      console.error("Error loading barber availability:", error);
+      toast({ status: "error", description: "Failed to load availability" });
+    } finally {
+      setIsLoading(false);
+    }
+  }, [toast, user?.Jwt]);
+
+  useEffect(() => {
+    refreshAvailability();
+  }, [refreshAvailability]);
+
+  const handleDrawerClose = () => {
+    setDrawerOpen(false);
+    setDrawerMode(null);
+    setSelectedAvailability(null);
+    setDeleteSubmitting(false);
+  };
+
+  const handleFormSubmit = async (values: AvailabilityFormValues) => {
+    if (!user?.Jwt) {
+      toast({ status: "error", description: "You must be logged in" });
+      return;
+    }
+
+    if (drawerMode === "create" && typeof values.day_of_week !== "number") {
+      toast({ status: "error", description: "Please select a day" });
+      return;
+    }
+
+    setFormSubmitting(true);
+
+    try {
+      if (drawerMode === "create") {
+        await createBarberAvailability(
+          {
+            day_of_week:
+              typeof values.day_of_week === "number" ? values.day_of_week : 0,
+            start_time: values.start_time,
+            end_time: values.end_time,
+            is_active: values.is_active,
+          },
+          user.Jwt
+        );
+
+        toast({
+          status: "success",
+          description: "Availability saved",
+        });
+      } else if (drawerMode === "edit" && selectedAvailability) {
+        await updateBarberAvailability(
+          selectedAvailability.id,
+          {
+            start_time: values.start_time,
+            end_time: values.end_time,
+            is_active: values.is_active,
+          },
+          user.Jwt
+        );
+
+        toast({
+          status: "success",
+          description: "Availability updated",
+        });
+      }
+
+      handleDrawerClose();
+      await refreshAvailability();
+    } catch (error) {
+      console.error("Error saving availability:", error);
+      toast({
+        status: "error",
+        description:
+          error instanceof Error
+            ? error.message
+            : "Failed to save availability",
+      });
+    } finally {
+      setFormSubmitting(false);
+    }
+  };
+
+  const handleDeleteSelected = async () => {
+    if (!user?.Jwt) {
+      toast({ status: "error", description: "You must be logged in" });
+      return;
+    }
+
+    if (!selectedAvailability?.id) {
+      toast({ status: "error", description: "No availability selected" });
+      return;
+    }
+
+    setDeleteSubmitting(true);
+    try {
+      await deleteBarberAvailability(selectedAvailability.id, user.Jwt);
+      toast({ status: "success", description: "Availability removed" });
+
+      handleDrawerClose();
+      await refreshAvailability();
+    } catch (error) {
+      console.error("Error deleting availability:", error);
+      toast({
+        status: "error",
+        description:
+          error instanceof Error
+            ? error.message
+            : "Failed to delete availability",
+      });
+    } finally {
+      setDeleteSubmitting(false);
+    }
+  };
+
+  const sortedAvailability = useMemo(() => {
+    return [...availability].sort((a, b) => {
+      const aDay = getComparableDayValue(a.day_of_week);
+      const bDay = getComparableDayValue(b.day_of_week);
+
+      if (aDay === bDay) {
+        return a.start_time.localeCompare(b.start_time);
+      }
+      return aDay - bDay;
+    });
+  }, [availability]);
+
+  const unavailableDays = useMemo(() => {
+    return Array.from(
+      new Set(
+        availability.map((item) => getComparableDayValue(item.day_of_week))
+      )
+    );
+  }, [availability]);
+
+  const isAuthenticated = Boolean(user?.Jwt);
+
+  return (
+    <div className="flex-1 space-y-4 p-6 pt-6">
+      <div className="flex items-center justify-between">
+        <Heading
+          title="My Availability"
+          description="Manage your weekly schedule"
+        />
+        <Button
+          onClick={() => {
+            setDrawerMode("create");
+            setSelectedAvailability(null);
+            setDrawerOpen(true);
+          }}
+          className="flex items-center gap-2"
+          disabled={!isAuthenticated}
+        >
+          <PlusIcon className="h-4 w-4" />
+          Add availability
+        </Button>
+      </div>
+
+      <Separator />
+
+      <Button variant="outline" className="mb-4" asChild>
+        <Link href="/manage/barbershop">← Back to Barbershop</Link>
+      </Button>
+
+      <div className="rounded-xl overflow-hidden border">
+        <Table className="border-collapse">
+          <TableHeader className="bg-muted/100">
+            <TableRow className="hover:bg-transparent border-b">
+              <TableHead className="px-6 py-4 text-sm font-semibold uppercase tracking-wider border-b">
+                Day
+              </TableHead>
+              <TableHead className="px-6 py-4 text-sm font-semibold uppercase tracking-wider border-b">
+                Hours
+              </TableHead>
+              <TableHead className="px-6 py-4 text-sm font-semibold uppercase tracking-wider border-b">
+                Status
+              </TableHead>
+              <TableHead className="px-6 py-4 text-sm font-semibold uppercase tracking-wider border-b">
+                Updated
+              </TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {!isAuthenticated ? (
+              <TableRow>
+                <TableCell
+                  colSpan={4}
+                  className="h-24 px-6 py-8 text-center text-muted-foreground"
+                >
+                  Sign in as a barber to manage availability.
+                </TableCell>
+              </TableRow>
+            ) : isLoading ? (
+              <TableRow>
+                <TableCell
+                  colSpan={4}
+                  className="h-24 px-6 py-8 text-center text-muted-foreground"
+                >
+                  Loading availability…
+                </TableCell>
+              </TableRow>
+            ) : sortedAvailability.length === 0 ? (
+              <TableRow>
+                <TableCell
+                  colSpan={4}
+                  className="h-24 px-6 py-8 text-center text-muted-foreground"
+                >
+                  No availability configured yet.
+                </TableCell>
+              </TableRow>
+            ) : (
+              sortedAvailability.map((item) => (
+                <TableRow
+                  key={item.id}
+                  className="border-b hover:bg-muted/100 transition-colors duration-150 ease-in-out even:bg-muted/50 cursor-pointer"
+                  role="button"
+                  tabIndex={0}
+                  onClick={() => {
+                    setDrawerMode("edit");
+                    setSelectedAvailability(item);
+                    setDrawerOpen(true);
+                  }}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter" || event.key === " ") {
+                      event.preventDefault();
+                      setDrawerMode("edit");
+                      setSelectedAvailability(item);
+                      setDrawerOpen(true);
+                    }
+                  }}
+                >
+                  <TableCell className="px-6 py-4 text-sm font-semibold">
+                    {dayOptions.find(
+                      (day) =>
+                        day.value === getComparableDayValue(item.day_of_week)
+                    )?.label ||
+                      `Day ${getComparableDayValue(item.day_of_week)}`}
+                  </TableCell>
+                  <TableCell className="px-6 py-4 text-sm font-medium">
+                    {formatDisplayTime(item.start_time)} –{" "}
+                    {formatDisplayTime(item.end_time)}
+                  </TableCell>
+                  <TableCell className="px-6 py-4 text-sm font-medium">
+                    <Badge variant={item.is_active ? "secondary" : "outline"}>
+                      {item.is_active ? "Active" : "Inactive"}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="px-6 py-4 text-sm text-muted-foreground">
+                    {formatDate(item.updated_at || item.created_at || "") ||
+                      "—"}
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      <RightDrawer
+        drawerOpen={drawerOpen}
+        handleDrawerClose={handleDrawerClose}
+        drawerWidth="w-[420px]"
+      >
+        <div className="p-4">
+          <h2 className="text-2xl font-bold tracking-tight mb-4">
+            {drawerMode === "edit" ? "Edit availability" : "Add availability"}
+          </h2>
+          <AvailabilityForm
+            mode={drawerMode === "edit" ? "edit" : "create"}
+            onSubmit={handleFormSubmit}
+            onCancel={handleDrawerClose}
+            initialData={drawerMode === "edit" ? selectedAvailability : null}
+            isSubmitting={formSubmitting}
+            unavailableDays={drawerMode === "edit" ? [] : unavailableDays}
+            onDelete={drawerMode === "edit" ? handleDeleteSelected : undefined}
+            isDeleting={deleteSubmitting}
+          />
+        </div>
+      </RightDrawer>
+    </div>
+  );
+}

--- a/services/barberAvailability.ts
+++ b/services/barberAvailability.ts
@@ -1,0 +1,141 @@
+import { addAuthHeader } from "@/lib/auth-header";
+import getValue from "@/configs/constants";
+
+export interface BarberAvailabilityRecord {
+  id: string;
+  day_of_week: number;
+  start_time: string;
+  end_time: string;
+  is_active: boolean;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface WeeklyAvailabilityResponse {
+  barber_id?: string;
+  barber_name?: string;
+  availability?: BarberAvailabilityRecord[];
+}
+
+export interface SetAvailabilityRequest {
+  day_of_week: number;
+  start_time: string;
+  end_time: string;
+  is_active?: boolean;
+}
+
+export interface UpdateAvailabilityRequest {
+  start_time: string;
+  end_time: string;
+  is_active?: boolean;
+}
+
+export async function getMyBarberAvailability(
+  jwt: string
+): Promise<WeeklyAvailabilityResponse> {
+  try {
+    const response = await fetch(
+      `${getValue("API")}haircuts/barbers/me/availability`,
+      {
+        method: "GET",
+        ...addAuthHeader(jwt),
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error(
+        `Failed to fetch barber availability: ${response.status} ${response.statusText}`
+      );
+    }
+
+    return response.json();
+  } catch (error) {
+    console.error("Error fetching barber availability:", error);
+    throw error;
+  }
+}
+
+export async function createBarberAvailability(
+  payload: SetAvailabilityRequest,
+  jwt: string
+): Promise<BarberAvailabilityRecord> {
+  try {
+    const response = await fetch(
+      `${getValue("API")}haircuts/barbers/me/availability`,
+      {
+        method: "POST",
+        ...addAuthHeader(jwt),
+        body: JSON.stringify(payload),
+      }
+    );
+
+    if (!response.ok) {
+      const message = await response.text();
+      throw new Error(
+        message ||
+          `Failed to create availability: ${response.status} ${response.statusText}`
+      );
+    }
+
+    return response.json();
+  } catch (error) {
+    console.error("Error creating barber availability:", error);
+    throw error;
+  }
+}
+
+export async function updateBarberAvailability(
+  id: string,
+  payload: UpdateAvailabilityRequest,
+  jwt: string
+): Promise<BarberAvailabilityRecord> {
+  try {
+    const response = await fetch(
+      `${getValue("API")}haircuts/barbers/me/availability/${id}`,
+      {
+        method: "PUT",
+        ...addAuthHeader(jwt),
+        body: JSON.stringify(payload),
+      }
+    );
+
+    if (!response.ok) {
+      const message = await response.text();
+      throw new Error(
+        message ||
+          `Failed to update availability: ${response.status} ${response.statusText}`
+      );
+    }
+
+    return response.json();
+  } catch (error) {
+    console.error(`Error updating barber availability ${id}:`, error);
+    throw error;
+  }
+}
+
+export async function deleteBarberAvailability(
+  id: string,
+  jwt: string
+): Promise<void> {
+  try {
+    const response = await fetch(
+      `${getValue("API")}haircuts/barbers/me/availability/${id}`,
+      {
+        method: "DELETE",
+        ...addAuthHeader(jwt),
+      }
+    );
+
+    if (!response.ok) {
+      const message = await response.text();
+      throw new Error(
+        message ||
+          `Failed to delete availability: ${response.status} ${response.statusText}`
+      );
+    }
+  } catch (error) {
+    console.error(`Error deleting barber availability ${id}:`, error);
+    throw error;
+  }
+}


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
- Created barber shop availability page
- Created availability form
- Updated barber page component 
- Created manage barber availability 
- Created barber availability services 

---

# 🧠 Reason for Changes

<!-- Explain why this change was necessary -->
- Creating the barber shop availability page wires the dashboard route to the new management component so barbers can reach the availability interface directly from /manage/barbershop/availability.

- Building the AvailabilityForm encapsulates the normalized day-of-week mapping, validation, and consistent save/delete controls required to create and update slots within the drawer workflow.

- Updating the BarberPage navigation adds a shortcut that points barbers to the availability manager alongside existing management links, making the new feature discoverable.

- Implementing ManageBarberAvailability supplies the styled table, drawer interactions, and authenticated handlers necessary for barbers to list, create, edit, and delete their weekly availability using the new endpoints.

- Adding the barberAvailability service helpers centralizes the authenticated GET/POST/PUT/DELETE requests so the UI can consistently call the availability endpoints with the barber’s JWT.
---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [X] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [ ] Backend APIs tested via Postman
- [X] No console errors (Frontend)
- [ ] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---



# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
- https://trello.com/c/TTqVSW0I/342-barber-availability

---



