### PR TITLE
[Feature] Added label for type of event on calendar info panel 

### DIFF
--- a/components/calendar/dialog/calendar-manage-event-drawer.tsx
+++ b/components/calendar/dialog/calendar-manage-event-drawer.tsx
@@ -45,6 +45,9 @@ export default function CalendarManageEventDrawer() {
   const [activeTab, setActiveTab] = useState("details");
 
   const eventType = selectedEvent?.program?.type?.toLowerCase();
+  const eventTypeLabel = eventType
+    ? eventType.charAt(0).toUpperCase() + eventType.slice(1)
+    : "Event";
   const showStaffTab =
     !!selectedEvent && eventType !== "game" && eventType !== "practice";
 
@@ -155,6 +158,11 @@ export default function CalendarManageEventDrawer() {
               ) : (
                 <div className="space-y-6">
                   <div className="space-y-2">
+                    {eventTypeLabel && (
+                      <p className="font-bold uppercase text-primary">
+                        {eventTypeLabel}
+                      </p>
+                    )}
                     <h1 className="text-xl font-semibold">
                       {selectedEvent.program.name || "Unnamed Event"}
                     </h1>


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
- Added to calendar event drawer

---

# 🧠 Reason for Changes

<!-- Explain why this change was necessary -->
- Adding the event type heading to the manage-event drawer ensures staff instantly see whether the selected calendar entry is a game, practice, or another event instead of just the team name.
---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [X] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [ ] Backend APIs tested via Postman
- [X] No console errors (Frontend)
- [ ] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---



# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
- https://trello.com/c/7eVZggzh/346-add-games-practice-program-on-calendar-events

---


