### PR TITLE
[Feature] Add parent-child linkage with Family tab, link/unlink support

### DIFF
--- a/app/api/docs/swagger.json
+++ b/app/api/docs/swagger.json
@@ -1631,6 +1631,345 @@
         }
       }
     },
+    "/applications": {
+      "get": {
+        "security": [
+          {
+            "Bearer": []
+          }
+        ],
+        "description": "Returns all job applications across all job postings. Admin only.",
+        "produces": ["application/json"],
+        "tags": ["careers"],
+        "summary": "List all applications",
+        "responses": {
+          "200": {
+            "description": "List of all applications",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/dto.JobApplicationResponse"
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          }
+        }
+      }
+    },
+    "/applications/{id}": {
+      "get": {
+        "security": [
+          {
+            "Bearer": []
+          }
+        ],
+        "description": "Returns a single job application with full details. Admin only.",
+        "produces": ["application/json"],
+        "tags": ["careers"],
+        "summary": "Get application by ID",
+        "parameters": [
+          {
+            "type": "string",
+            "format": "uuid",
+            "description": "Application ID",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Application details",
+            "schema": {
+              "$ref": "#/definitions/dto.JobApplicationResponse"
+            }
+          },
+          "400": {
+            "description": "Bad Request: Invalid ID",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "404": {
+            "description": "Not Found: Application not found",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          }
+        }
+      }
+    },
+    "/applications/{id}/notes": {
+      "patch": {
+        "security": [
+          {
+            "Bearer": []
+          }
+        ],
+        "description": "Updates internal notes for an application. Admin only.",
+        "consumes": ["application/json"],
+        "produces": ["application/json"],
+        "tags": ["careers"],
+        "summary": "Update application notes",
+        "parameters": [
+          {
+            "type": "string",
+            "format": "uuid",
+            "description": "Application ID",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "description": "Notes content",
+            "name": "notes",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/dto.UpdateApplicationNotesRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Updated application",
+            "schema": {
+              "$ref": "#/definitions/dto.JobApplicationResponse"
+            }
+          },
+          "400": {
+            "description": "Bad Request: Invalid input",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "404": {
+            "description": "Not Found: Application not found",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          }
+        }
+      }
+    },
+    "/applications/{id}/rating": {
+      "patch": {
+        "security": [
+          {
+            "Bearer": []
+          }
+        ],
+        "description": "Updates the rating (1-5) for an application. Admin only.",
+        "consumes": ["application/json"],
+        "produces": ["application/json"],
+        "tags": ["careers"],
+        "summary": "Update application rating",
+        "parameters": [
+          {
+            "type": "string",
+            "format": "uuid",
+            "description": "Application ID",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "description": "Rating value (1-5)",
+            "name": "rating",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/dto.UpdateApplicationRatingRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Updated application",
+            "schema": {
+              "$ref": "#/definitions/dto.JobApplicationResponse"
+            }
+          },
+          "400": {
+            "description": "Bad Request: Invalid input",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "404": {
+            "description": "Not Found: Application not found",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          }
+        }
+      }
+    },
+    "/applications/{id}/status": {
+      "patch": {
+        "security": [
+          {
+            "Bearer": []
+          }
+        ],
+        "description": "Updates application status and sends notification email to applicant. Admin only.",
+        "consumes": ["application/json"],
+        "produces": ["application/json"],
+        "tags": ["careers"],
+        "summary": "Update application status",
+        "parameters": [
+          {
+            "type": "string",
+            "format": "uuid",
+            "description": "Application ID",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "description": "New status",
+            "name": "status",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/dto.UpdateApplicationStatusRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Updated application",
+            "schema": {
+              "$ref": "#/definitions/dto.JobApplicationResponse"
+            }
+          },
+          "400": {
+            "description": "Bad Request: Invalid input",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "404": {
+            "description": "Not Found: Application not found",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          }
+        }
+      }
+    },
     "/athletes": {
       "get": {
         "description": "Retrieves a paginated list of athletes with profile details and stats.",
@@ -4827,6 +5166,245 @@
         }
       }
     },
+    "/family/admin/link/{id}": {
+      "delete": {
+        "description": "Removes the parent-child link for a user (admin only)",
+        "produces": ["application/json"],
+        "tags": ["family"],
+        "summary": "Admin unlink parent-child",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Child user ID",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Link removed"
+          },
+          "400": {
+            "description": "Bad Request: No parent link exists",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "403": {
+            "description": "Forbidden: Admin only",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "404": {
+            "description": "User not found",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          }
+        }
+      }
+    },
+    "/family/children": {
+      "get": {
+        "description": "Gets all children linked to the authenticated parent",
+        "produces": ["application/json"],
+        "tags": ["family"],
+        "summary": "Get children",
+        "responses": {
+          "200": {
+            "description": "Children list",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/family.ChildResponse"
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          }
+        }
+      }
+    },
+    "/family/link/confirm": {
+      "post": {
+        "description": "Confirms a link request using the verification code sent via email",
+        "consumes": ["application/json"],
+        "produces": ["application/json"],
+        "tags": ["family"],
+        "summary": "Confirm a parent-child link request",
+        "parameters": [
+          {
+            "description": "Verification code",
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/family.ConfirmLinkRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Link confirmation status",
+            "schema": {
+              "$ref": "#/definitions/family.ConfirmLinkResponse"
+            }
+          },
+          "400": {
+            "description": "Bad Request: Invalid input",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "403": {
+            "description": "Forbidden: Code not for this user",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "404": {
+            "description": "Invalid or expired code",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          }
+        }
+      }
+    },
+    "/family/link/request": {
+      "post": {
+        "description": "Initiates a link request between parent and child. If caller has no parent, they're adding a child. If caller has a parent, they're changing/adding a parent.",
+        "consumes": ["application/json"],
+        "produces": ["application/json"],
+        "tags": ["family"],
+        "summary": "Initiate a parent-child link request",
+        "parameters": [
+          {
+            "description": "Target email address",
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/family.RequestLinkRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Link request initiated",
+            "schema": {
+              "$ref": "#/definitions/family.RequestLinkResponse"
+            }
+          },
+          "400": {
+            "description": "Bad Request: Invalid input",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "404": {
+            "description": "User not found",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "409": {
+            "description": "Pending request already exists",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          }
+        }
+      },
+      "delete": {
+        "description": "Cancels the caller's pending link request",
+        "produces": ["application/json"],
+        "tags": ["family"],
+        "summary": "Cancel a pending link request",
+        "responses": {
+          "204": {
+            "description": "Request cancelled"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "404": {
+            "description": "No pending request found",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          }
+        }
+      }
+    },
+    "/family/link/requests": {
+      "get": {
+        "description": "Gets all pending link requests where the user is child, new parent, or old parent",
+        "produces": ["application/json"],
+        "tags": ["family"],
+        "summary": "Get pending link requests",
+        "responses": {
+          "200": {
+            "description": "Pending requests",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/family.PendingRequestResponse"
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          }
+        }
+      }
+    },
     "/games": {
       "get": {
         "description": "Retrieves a list of games with optional time-based filtering and location/court filtering.",
@@ -5854,6 +6432,562 @@
         "responses": {
           "200": {
             "description": "Retry statistics",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          }
+        }
+      }
+    },
+    "/jobs": {
+      "get": {
+        "description": "Returns all job postings with status \"published\" for public viewing",
+        "produces": ["application/json"],
+        "tags": ["careers"],
+        "summary": "List published job postings",
+        "responses": {
+          "200": {
+            "description": "List of published job postings",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/dto.JobPostingResponse"
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          }
+        }
+      },
+      "post": {
+        "security": [
+          {
+            "Bearer": []
+          }
+        ],
+        "description": "Creates a new job posting with draft status. Admin only.",
+        "consumes": ["application/json"],
+        "produces": ["application/json"],
+        "tags": ["careers"],
+        "summary": "Create job posting",
+        "parameters": [
+          {
+            "description": "Job posting details",
+            "name": "job",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/dto.CreateJobPostingRequest"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created job posting",
+            "schema": {
+              "$ref": "#/definitions/dto.JobPostingResponse"
+            }
+          },
+          "400": {
+            "description": "Bad Request: Invalid input",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          }
+        }
+      }
+    },
+    "/jobs/all": {
+      "get": {
+        "security": [
+          {
+            "Bearer": []
+          }
+        ],
+        "description": "Returns all job postings including drafts, closed, etc. Admin only.",
+        "produces": ["application/json"],
+        "tags": ["careers"],
+        "summary": "List all job postings",
+        "responses": {
+          "200": {
+            "description": "List of all job postings",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/dto.JobPostingResponse"
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          }
+        }
+      }
+    },
+    "/jobs/{id}": {
+      "get": {
+        "description": "Returns a job posting. Public users only see published postings; admins see all statuses.",
+        "produces": ["application/json"],
+        "tags": ["careers"],
+        "summary": "Get job posting by ID",
+        "parameters": [
+          {
+            "type": "string",
+            "format": "uuid",
+            "description": "Job Posting ID",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Job posting details",
+            "schema": {
+              "$ref": "#/definitions/dto.JobPostingResponse"
+            }
+          },
+          "400": {
+            "description": "Bad Request: Invalid ID",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "404": {
+            "description": "Not Found: Job posting not found",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          }
+        }
+      },
+      "put": {
+        "security": [
+          {
+            "Bearer": []
+          }
+        ],
+        "description": "Updates job posting details. Admin only.",
+        "consumes": ["application/json"],
+        "produces": ["application/json"],
+        "tags": ["careers"],
+        "summary": "Update job posting",
+        "parameters": [
+          {
+            "type": "string",
+            "format": "uuid",
+            "description": "Job Posting ID",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "description": "Updated job posting details",
+            "name": "job",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/dto.UpdateJobPostingRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Updated job posting",
+            "schema": {
+              "$ref": "#/definitions/dto.JobPostingResponse"
+            }
+          },
+          "400": {
+            "description": "Bad Request: Invalid input",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "404": {
+            "description": "Not Found: Job posting not found",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          }
+        }
+      },
+      "delete": {
+        "security": [
+          {
+            "Bearer": []
+          }
+        ],
+        "description": "Permanently deletes a job posting. Admin only.",
+        "tags": ["careers"],
+        "summary": "Delete job posting",
+        "parameters": [
+          {
+            "type": "string",
+            "format": "uuid",
+            "description": "Job Posting ID",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Job posting deleted successfully"
+          },
+          "400": {
+            "description": "Bad Request: Invalid ID",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "404": {
+            "description": "Not Found: Job posting not found",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          }
+        }
+      }
+    },
+    "/jobs/{id}/apply": {
+      "post": {
+        "description": "Submit an application for a published job posting with resume file upload",
+        "consumes": ["multipart/form-data"],
+        "produces": ["application/json"],
+        "tags": ["careers"],
+        "summary": "Submit job application",
+        "parameters": [
+          {
+            "type": "string",
+            "format": "uuid",
+            "description": "Job Posting ID",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Applicant first name",
+            "name": "first_name",
+            "in": "formData",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Applicant last name",
+            "name": "last_name",
+            "in": "formData",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Applicant email",
+            "name": "email",
+            "in": "formData",
+            "required": true
+          },
+          {
+            "type": "file",
+            "description": "Resume file (PDF, DOC, DOCX)",
+            "name": "resume",
+            "in": "formData",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Phone number",
+            "name": "phone",
+            "in": "formData"
+          },
+          {
+            "type": "string",
+            "description": "Cover letter text",
+            "name": "cover_letter",
+            "in": "formData"
+          },
+          {
+            "type": "string",
+            "description": "LinkedIn profile URL",
+            "name": "linkedin_url",
+            "in": "formData"
+          },
+          {
+            "type": "string",
+            "description": "Portfolio URL",
+            "name": "portfolio_url",
+            "in": "formData"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Application submitted successfully",
+            "schema": {
+              "$ref": "#/definitions/dto.JobApplicationResponse"
+            }
+          },
+          "400": {
+            "description": "Bad Request: Invalid input or missing required fields",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "404": {
+            "description": "Not Found: Job posting not found or not accepting applications",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "429": {
+            "description": "Too Many Requests: Rate limit exceeded",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          }
+        }
+      }
+    },
+    "/jobs/{id}/status": {
+      "patch": {
+        "security": [
+          {
+            "Bearer": []
+          }
+        ],
+        "description": "Updates job posting status (draft, published, closed). Admin only.",
+        "consumes": ["application/json"],
+        "produces": ["application/json"],
+        "tags": ["careers"],
+        "summary": "Update job posting status",
+        "parameters": [
+          {
+            "type": "string",
+            "format": "uuid",
+            "description": "Job Posting ID",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "description": "New status",
+            "name": "status",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/dto.UpdateJobStatusRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Updated job posting",
+            "schema": {
+              "$ref": "#/definitions/dto.JobPostingResponse"
+            }
+          },
+          "400": {
+            "description": "Bad Request: Invalid input",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "404": {
+            "description": "Not Found: Job posting not found",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          }
+        }
+      }
+    },
+    "/jobs/{job_id}/applications": {
+      "get": {
+        "security": [
+          {
+            "Bearer": []
+          }
+        ],
+        "description": "Returns all applications for a specific job posting. Admin only.",
+        "produces": ["application/json"],
+        "tags": ["careers"],
+        "summary": "List applications by job",
+        "parameters": [
+          {
+            "type": "string",
+            "format": "uuid",
+            "description": "Job Posting ID",
+            "name": "job_id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of applications",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/dto.JobApplicationResponse"
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request: Invalid ID",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
             "schema": {
               "type": "object",
               "additionalProperties": true
@@ -7712,6 +8846,15 @@
         "consumes": ["application/json"],
         "produces": ["application/json"],
         "tags": ["credits"],
+        "parameters": [
+          {
+            "type": "string",
+            "format": "uuid",
+            "description": "Child user ID (for parent viewing child's credits)",
+            "name": "child_id",
+            "in": "query"
+          }
+        ],
         "responses": {
           "200": {
             "description": "Credit balance retrieved successfully",
@@ -7722,6 +8865,13 @@
           },
           "401": {
             "description": "Unauthorized",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "403": {
+            "description": "Forbidden: Not authorized to view child's credits",
             "schema": {
               "type": "object",
               "additionalProperties": true
@@ -7764,6 +8914,13 @@
             "description": "Number of items to skip",
             "name": "offset",
             "in": "query"
+          },
+          {
+            "type": "string",
+            "format": "uuid",
+            "description": "Child user ID (for parent viewing child's transactions)",
+            "name": "child_id",
+            "in": "query"
           }
         ],
         "responses": {
@@ -7776,6 +8933,13 @@
           },
           "401": {
             "description": "Unauthorized",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "403": {
+            "description": "Forbidden: Not authorized to view child's transactions",
             "schema": {
               "type": "object",
               "additionalProperties": true
@@ -7801,6 +8965,15 @@
         "consumes": ["application/json"],
         "produces": ["application/json"],
         "tags": ["credits"],
+        "parameters": [
+          {
+            "type": "string",
+            "format": "uuid",
+            "description": "Child user ID (for parent viewing child's weekly usage)",
+            "name": "child_id",
+            "in": "query"
+          }
+        ],
         "responses": {
           "200": {
             "description": "Weekly usage retrieved successfully\" example({\"customer_id\":\"uuid\",\"current_week_usage\":1,\"weekly_limit\":2,\"remaining_credits\":1})",
@@ -7811,6 +8984,13 @@
           },
           "401": {
             "description": "Unauthorized",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "403": {
+            "description": "Forbidden: Not authorized to view child's weekly usage",
             "schema": {
               "type": "object",
               "additionalProperties": true
@@ -8016,6 +9196,13 @@
             "description": "Filter events by day (YYYY-MM-DD)",
             "name": "day",
             "in": "query"
+          },
+          {
+            "type": "string",
+            "format": "uuid",
+            "description": "Child user ID (for parent viewing child's events)",
+            "name": "child_id",
+            "in": "query"
           }
         ],
         "responses": {
@@ -8032,6 +9219,13 @@
               "type": "object",
               "additionalProperties": true
             }
+          },
+          "403": {
+            "description": "Forbidden: Not authorized to view child's events",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
           }
         }
       }
@@ -8041,18 +9235,22 @@
         "security": [
           {
             "Bearer": []
-          },
-          {
-            "Bearer": []
           }
         ],
-        "produces": ["application/json", "application/json"],
-        "tags": ["games", "games"],
+        "produces": ["application/json"],
+        "tags": ["games"],
         "parameters": [
           {
             "type": "string",
             "description": "Filter by time: upcoming, past, or live",
             "name": "filter",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "format": "uuid",
+            "description": "Child user ID (for parent viewing child's games)",
+            "name": "child_id",
             "in": "query"
           }
         ],
@@ -8068,6 +9266,13 @@
           },
           "401": {
             "description": "Unauthorized",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "403": {
+            "description": "Forbidden: Not authorized to view child's games",
             "schema": {
               "type": "object",
               "additionalProperties": true
@@ -8198,6 +9403,15 @@
         "produces": ["application/json"],
         "tags": ["schedule"],
         "summary": "Get my schedule",
+        "parameters": [
+          {
+            "type": "string",
+            "format": "uuid",
+            "description": "Child user ID (for parent viewing child's schedule)",
+            "name": "child_id",
+            "in": "query"
+          }
+        ],
         "responses": {
           "200": {
             "description": "Schedule retrieved successfully with events, games, and practices",
@@ -8207,6 +9421,13 @@
           },
           "401": {
             "description": "Unauthorized",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "403": {
+            "description": "Forbidden: Not authorized to view child's schedule",
             "schema": {
               "type": "object",
               "additionalProperties": true
@@ -11191,8 +12412,14 @@
     "customer.Response": {
       "type": "object",
       "properties": {
+        "archived_at": {
+          "type": "string"
+        },
         "country_code": {
           "type": "string"
+        },
+        "days_until_deletion": {
+          "type": "integer"
         },
         "deleted_at": {
           "type": "string"
@@ -11231,6 +12458,9 @@
           "$ref": "#/definitions/customer.MembershipResponseDto"
         },
         "notes": {
+          "type": "string"
+        },
+        "pending_email": {
           "type": "string"
         },
         "phone": {
@@ -11468,6 +12698,71 @@
         }
       }
     },
+    "dto.CreateJobPostingRequest": {
+      "type": "object",
+      "required": [
+        "description",
+        "employment_type",
+        "location_type",
+        "position",
+        "title"
+      ],
+      "properties": {
+        "closing_date": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "employment_type": {
+          "type": "string",
+          "enum": [
+            "full_time",
+            "part_time",
+            "contract",
+            "internship",
+            "volunteer"
+          ]
+        },
+        "location_type": {
+          "type": "string",
+          "enum": ["on_site", "remote", "hybrid"]
+        },
+        "nice_to_have": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "position": {
+          "type": "string"
+        },
+        "requirements": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "responsibilities": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "salary_max": {
+          "type": "number"
+        },
+        "salary_min": {
+          "type": "number"
+        },
+        "show_salary": {
+          "type": "boolean"
+        },
+        "title": {
+          "type": "string"
+        }
+      }
+    },
     "dto.CreateProviderRequest": {
       "type": "object",
       "required": ["name"],
@@ -11545,6 +12840,127 @@
         }
       }
     },
+    "dto.JobApplicationResponse": {
+      "type": "object",
+      "properties": {
+        "cover_letter": {
+          "type": "string"
+        },
+        "created_at": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string"
+        },
+        "first_name": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "internal_notes": {
+          "type": "string"
+        },
+        "job_id": {
+          "type": "string"
+        },
+        "last_name": {
+          "type": "string"
+        },
+        "linkedin_url": {
+          "type": "string"
+        },
+        "phone": {
+          "type": "string"
+        },
+        "portfolio_url": {
+          "type": "string"
+        },
+        "rating": {
+          "type": "integer"
+        },
+        "resume_url": {
+          "type": "string"
+        },
+        "reviewed_by": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
+        },
+        "updated_at": {
+          "type": "string"
+        }
+      }
+    },
+    "dto.JobPostingResponse": {
+      "type": "object",
+      "properties": {
+        "closing_date": {
+          "type": "string"
+        },
+        "created_at": {
+          "type": "string"
+        },
+        "created_by": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "employment_type": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "location_type": {
+          "type": "string"
+        },
+        "nice_to_have": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "position": {
+          "type": "string"
+        },
+        "published_at": {
+          "type": "string"
+        },
+        "requirements": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "responsibilities": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "salary_max": {
+          "type": "string"
+        },
+        "salary_min": {
+          "type": "string"
+        },
+        "show_salary": {
+          "type": "boolean"
+        },
+        "status": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "updated_at": {
+          "type": "string"
+        }
+      }
+    },
     "dto.NewsletterRequest": {
       "type": "object",
       "properties": {
@@ -11588,6 +13004,118 @@
         },
         "type": {
           "type": "string"
+        }
+      }
+    },
+    "dto.UpdateApplicationNotesRequest": {
+      "type": "object",
+      "properties": {
+        "notes": {
+          "type": "string"
+        }
+      }
+    },
+    "dto.UpdateApplicationRatingRequest": {
+      "type": "object",
+      "required": ["rating"],
+      "properties": {
+        "rating": {
+          "type": "integer",
+          "maximum": 5,
+          "minimum": 1
+        }
+      }
+    },
+    "dto.UpdateApplicationStatusRequest": {
+      "type": "object",
+      "required": ["status"],
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": [
+            "received",
+            "reviewing",
+            "interview",
+            "offer",
+            "hired",
+            "rejected",
+            "withdrawn"
+          ]
+        }
+      }
+    },
+    "dto.UpdateJobPostingRequest": {
+      "type": "object",
+      "required": [
+        "description",
+        "employment_type",
+        "location_type",
+        "position",
+        "title"
+      ],
+      "properties": {
+        "closing_date": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "employment_type": {
+          "type": "string",
+          "enum": [
+            "full_time",
+            "part_time",
+            "contract",
+            "internship",
+            "volunteer"
+          ]
+        },
+        "location_type": {
+          "type": "string",
+          "enum": ["on_site", "remote", "hybrid"]
+        },
+        "nice_to_have": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "position": {
+          "type": "string"
+        },
+        "requirements": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "responsibilities": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "salary_max": {
+          "type": "number"
+        },
+        "salary_min": {
+          "type": "number"
+        },
+        "show_salary": {
+          "type": "boolean"
+        },
+        "title": {
+          "type": "string"
+        }
+      }
+    },
+    "dto.UpdateJobStatusRequest": {
+      "type": "object",
+      "required": ["status"],
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": ["draft", "published", "closed", "archived"]
         }
       }
     },
@@ -12104,6 +13632,136 @@
         },
         "name": {
           "type": "string"
+        }
+      }
+    },
+    "family.ChildResponse": {
+      "type": "object",
+      "properties": {
+        "email": {
+          "type": "string"
+        },
+        "first_name": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "last_name": {
+          "type": "string"
+        },
+        "linked_at": {
+          "type": "string"
+        }
+      }
+    },
+    "family.ConfirmLinkRequest": {
+      "type": "object",
+      "required": ["code"],
+      "properties": {
+        "code": {
+          "type": "string"
+        }
+      }
+    },
+    "family.ConfirmLinkResponse": {
+      "type": "object",
+      "properties": {
+        "child_id": {
+          "type": "string"
+        },
+        "child_name": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        },
+        "status": {
+          "description": "\"complete\", \"pending_old_parent\", \"pending_new_parent\"",
+          "type": "string"
+        }
+      }
+    },
+    "family.PendingRequestResponse": {
+      "type": "object",
+      "properties": {
+        "awaiting_user_action": {
+          "type": "boolean"
+        },
+        "child_email": {
+          "type": "string"
+        },
+        "child_id": {
+          "type": "string"
+        },
+        "child_name": {
+          "type": "string"
+        },
+        "counterparty_verified": {
+          "type": "boolean"
+        },
+        "created_at": {
+          "type": "string"
+        },
+        "expires_at": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "initiated_by": {
+          "type": "string"
+        },
+        "new_parent_email": {
+          "type": "string"
+        },
+        "new_parent_id": {
+          "type": "string"
+        },
+        "new_parent_name": {
+          "type": "string"
+        },
+        "old_parent_email": {
+          "type": "string"
+        },
+        "old_parent_id": {
+          "type": "string"
+        },
+        "old_parent_name": {
+          "type": "string"
+        },
+        "old_parent_verified": {
+          "type": "boolean"
+        },
+        "requires_old_parent": {
+          "type": "boolean"
+        },
+        "user_role": {
+          "description": "\"child\", \"new_parent\", or \"old_parent\"",
+          "type": "string"
+        }
+      }
+    },
+    "family.RequestLinkRequest": {
+      "type": "object",
+      "required": ["target_email"],
+      "properties": {
+        "target_email": {
+          "type": "string"
+        }
+      }
+    },
+    "family.RequestLinkResponse": {
+      "type": "object",
+      "properties": {
+        "expires_at": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        },
+        "requires_old_parent": {
+          "type": "boolean"
         }
       }
     },

--- a/components/customers/CustomerInfoPanel.tsx
+++ b/components/customers/CustomerInfoPanel.tsx
@@ -9,6 +9,7 @@ import {
   WaiverUpload,
 } from "@/types/customer";
 import DetailsTab from "./infoTabs/CustomerDetails";
+import FamilyTab from "./infoTabs/FamilyTab";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -57,6 +58,7 @@ import {
   ExternalLink,
   AlertTriangle,
   Receipt,
+  Users,
   MoreHorizontal,
   Copy,
   Info,
@@ -1354,6 +1356,13 @@ export default function CustomerInfoPanel({
             >
               <Receipt className="h-4 w-4" />
               Payments
+            </TabsTrigger>
+            <TabsTrigger
+              value="family"
+              className="flex items-center gap-2 px-6 py-3 data-[state=active]:border-b-2 data-[state=active]:border-primary data-[state=active]:text-primary data-[state=active]:shadow-none rounded-none bg-transparent hover:bg-muted/50 transition-all"
+            >
+              <Users className="h-4 w-4" />
+              Family
             </TabsTrigger>
             {/* <TabsTrigger
               value="stats"
@@ -2698,6 +2707,15 @@ export default function CustomerInfoPanel({
               </div>
             </CardContent>
           </Card>
+        </TabsContent>
+
+        <TabsContent value="family">
+          <FamilyTab
+            customer={currentCustomer}
+            onCustomerUpdated={(updated) => {
+              setCurrentCustomer((prev) => ({ ...prev, ...updated }));
+            }}
+          />
         </TabsContent>
 
         {/* Stats Tab - This will show the athlete_info data that is available */}

--- a/components/customers/LinkChildDialog.tsx
+++ b/components/customers/LinkChildDialog.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  DialogDescription,
+  DialogHeader,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Loader2, Mail, CheckCircle2 } from "lucide-react";
+import { useToast } from "@/hooks/use-toast";
+import { requestFamilyLink } from "@/services/customer";
+
+interface LinkChildDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  jwt: string;
+  onLinkRequested: () => void;
+}
+
+export default function LinkChildDialog({
+  open,
+  onOpenChange,
+  jwt,
+  onLinkRequested,
+}: LinkChildDialogProps) {
+  const { toast } = useToast();
+  const [email, setEmail] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [sent, setSent] = useState(false);
+
+  const resetForm = () => {
+    setEmail("");
+    setSent(false);
+    setIsSubmitting(false);
+  };
+
+  const handleSubmit = async () => {
+    if (!email.trim()) return;
+    setIsSubmitting(true);
+    try {
+      const result = await requestFamilyLink(email.trim(), jwt);
+      if (result.error) {
+        toast({
+          status: "error",
+          description: result.error,
+          variant: "destructive",
+        });
+      } else {
+        setSent(true);
+        onLinkRequested();
+      }
+    } catch {
+      toast({
+        status: "error",
+        description: "Failed to send link request",
+        variant: "destructive",
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(isOpen) => {
+        if (!isOpen) resetForm();
+        onOpenChange(isOpen);
+      }}
+    >
+      <DialogContent className="sm:max-w-[450px]">
+        <DialogHeader>
+          <DialogTitle>Link Child Account</DialogTitle>
+          <DialogDescription>
+            Send a link request to a customer&apos;s email. They will receive a
+            verification code to confirm the parent-child association.
+          </DialogDescription>
+        </DialogHeader>
+
+        {sent ? (
+          <div className="text-center py-6 space-y-3">
+            <CheckCircle2 className="h-12 w-12 mx-auto text-emerald-500" />
+            <div>
+              <p className="font-medium">Link request sent</p>
+              <p className="text-sm text-muted-foreground mt-1">
+                A verification email has been sent to{" "}
+                <strong>{email}</strong>. The link will be established once
+                they confirm with their verification code.
+              </p>
+            </div>
+            <Button
+              variant="outline"
+              onClick={() => {
+                resetForm();
+                onOpenChange(false);
+              }}
+            >
+              Done
+            </Button>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            <div>
+              <Label htmlFor="link-email">Customer Email</Label>
+              <div className="relative mt-1.5">
+                <Mail className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+                <Input
+                  id="link-email"
+                  type="email"
+                  placeholder="child@example.com"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  className="pl-9"
+                  autoFocus
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" && email.trim()) handleSubmit();
+                  }}
+                />
+              </div>
+            </div>
+
+            <Button
+              className="w-full"
+              onClick={handleSubmit}
+              disabled={!email.trim() || isSubmitting}
+            >
+              {isSubmitting ? (
+                <>
+                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  Sending...
+                </>
+              ) : (
+                "Send Link Request"
+              )}
+            </Button>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/customers/infoTabs/FamilyTab.tsx
+++ b/components/customers/infoTabs/FamilyTab.tsx
@@ -1,0 +1,380 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import {
+  Users,
+  Link2,
+  Unlink,
+  Loader2,
+  User,
+  Mail,
+  Phone,
+} from "lucide-react";
+import { useToast } from "@/hooks/use-toast";
+import { Customer } from "@/types/customer";
+import {
+  getChildrenByParentId,
+  getCustomerById,
+  adminUnlinkChild,
+} from "@/services/customer";
+import { useUser } from "@/contexts/UserContext";
+import LinkChildDialog from "../LinkChildDialog";
+
+interface FamilyTabProps {
+  customer: Customer;
+  onCustomerUpdated?: (updated: Partial<Customer>) => void;
+}
+
+export default function FamilyTab({
+  customer,
+  onCustomerUpdated,
+}: FamilyTabProps) {
+  const { toast } = useToast();
+  const { user } = useUser();
+
+  const [children, setChildren] = useState<Customer[]>([]);
+  const [isLoadingChildren, setIsLoadingChildren] = useState(false);
+
+  const [parentCustomer, setParentCustomer] = useState<Customer | null>(null);
+  const [isLoadingParent, setIsLoadingParent] = useState(false);
+
+  const [linkDialogOpen, setLinkDialogOpen] = useState(false);
+  const [unlinkDialogOpen, setUnlinkDialogOpen] = useState(false);
+  const [childToUnlink, setChildToUnlink] = useState<Customer | null>(null);
+  const [isUnlinking, setIsUnlinking] = useState(false);
+  const [unlinkFromParentDialogOpen, setUnlinkFromParentDialogOpen] =
+    useState(false);
+  const [isUnlinkingFromParent, setIsUnlinkingFromParent] = useState(false);
+
+  const isChild = !!customer.parent_id;
+
+  const fetchChildren = useCallback(async () => {
+    if (!user?.Jwt || !customer.id) return;
+    setIsLoadingChildren(true);
+    try {
+      const result = await getChildrenByParentId(customer.id, user.Jwt);
+      setChildren(result);
+    } catch {
+      toast({
+        status: "error",
+        description: "Failed to load children",
+        variant: "destructive",
+      });
+    } finally {
+      setIsLoadingChildren(false);
+    }
+  }, [customer.id, user?.Jwt, toast]);
+
+  const fetchParent = useCallback(async () => {
+    if (!user?.Jwt || !customer.parent_id) return;
+    setIsLoadingParent(true);
+    try {
+      const result = await getCustomerById(customer.parent_id, user.Jwt);
+      setParentCustomer(result);
+    } catch {
+      toast({
+        status: "error",
+        description: "Failed to load parent information",
+        variant: "destructive",
+      });
+    } finally {
+      setIsLoadingParent(false);
+    }
+  }, [customer.parent_id, user?.Jwt, toast]);
+
+  useEffect(() => {
+    if (isChild) {
+      fetchParent();
+    }
+    fetchChildren();
+  }, [isChild, fetchParent, fetchChildren]);
+
+  const handleUnlinkChild = async () => {
+    if (!childToUnlink || !user?.Jwt) return;
+    setIsUnlinking(true);
+    try {
+      const error = await adminUnlinkChild(childToUnlink.id, user.Jwt);
+      if (error) {
+        toast({
+          status: "error",
+          description: error,
+          variant: "destructive",
+        });
+      } else {
+        toast({
+          status: "success",
+          description: `${childToUnlink.first_name} ${childToUnlink.last_name} has been unlinked`,
+        });
+        fetchChildren();
+      }
+    } catch {
+      toast({
+        status: "error",
+        description: "Failed to unlink child",
+        variant: "destructive",
+      });
+    } finally {
+      setIsUnlinking(false);
+      setUnlinkDialogOpen(false);
+      setChildToUnlink(null);
+    }
+  };
+
+  const handleUnlinkFromParent = async () => {
+    if (!user?.Jwt || !customer.id) return;
+    setIsUnlinkingFromParent(true);
+    try {
+      const error = await adminUnlinkChild(customer.id, user.Jwt);
+      if (error) {
+        toast({
+          status: "error",
+          description: error,
+          variant: "destructive",
+        });
+      } else {
+        toast({
+          status: "success",
+          description: "Unlinked from parent account",
+        });
+        setParentCustomer(null);
+        onCustomerUpdated?.({ parent_id: null });
+      }
+    } catch {
+      toast({
+        status: "error",
+        description: "Failed to unlink from parent",
+        variant: "destructive",
+      });
+    } finally {
+      setIsUnlinkingFromParent(false);
+      setUnlinkFromParentDialogOpen(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Parent Info Section */}
+      {isChild && (
+        <Card className="border-l-4 border-l-blue-500">
+          <CardContent className="pt-6">
+            <div className="flex items-center justify-between mb-4">
+              <div className="flex items-center gap-2">
+                <User className="h-5 w-5 text-blue-500" />
+                <h3 className="font-semibold text-lg">Parent Account</h3>
+              </div>
+              <Button
+                variant="outline"
+                size="sm"
+                className="text-destructive hover:text-destructive"
+                onClick={() => setUnlinkFromParentDialogOpen(true)}
+              >
+                <Unlink className="h-3 w-3 mr-1" />
+                Unlink
+              </Button>
+            </div>
+
+            {isLoadingParent ? (
+              <div className="flex items-center justify-center py-6">
+                <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+              </div>
+            ) : parentCustomer ? (
+              <div className="flex items-center gap-4 p-3 bg-muted/30 rounded-lg">
+                <div className="h-10 w-10 rounded-full bg-blue-100 flex items-center justify-center">
+                  <User className="h-5 w-5 text-blue-600" />
+                </div>
+                <div className="flex-1 space-y-1">
+                  <p className="font-medium">
+                    {parentCustomer.first_name} {parentCustomer.last_name}
+                  </p>
+                  {parentCustomer.email && (
+                    <div className="flex items-center gap-1.5 text-sm text-muted-foreground">
+                      <Mail className="h-3 w-3" />
+                      {parentCustomer.email}
+                    </div>
+                  )}
+                  {parentCustomer.phone && (
+                    <div className="flex items-center gap-1.5 text-sm text-muted-foreground">
+                      <Phone className="h-3 w-3" />
+                      {parentCustomer.phone}
+                    </div>
+                  )}
+                </div>
+              </div>
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                Parent information unavailable
+              </p>
+            )}
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Children Section */}
+      <Card className="border-l-4 border-l-yellow-500">
+        <CardContent className="pt-6">
+          <div className="flex items-center justify-between mb-4">
+            <div className="flex items-center gap-2">
+              <Users className="h-5 w-5 text-yellow-500" />
+              <h3 className="font-semibold text-lg">
+                Children
+                {children.length > 0 && (
+                  <Badge variant="secondary" className="ml-2">
+                    {children.length}
+                  </Badge>
+                )}
+              </h3>
+            </div>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setLinkDialogOpen(true)}
+            >
+              <Link2 className="h-3 w-3 mr-1" />
+              Link Child
+            </Button>
+          </div>
+
+          {isLoadingChildren ? (
+            <div className="flex items-center justify-center py-8">
+              <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+            </div>
+          ) : children.length === 0 ? (
+            <div className="text-center py-8">
+              <Users className="h-10 w-10 mx-auto text-muted-foreground/40 mb-3" />
+              <p className="text-sm text-muted-foreground">
+                No children linked to this account
+              </p>
+              <p className="text-xs text-muted-foreground mt-1">
+                Use the button above to initiate a link request
+              </p>
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {children.map((child) => (
+                <div
+                  key={child.id}
+                  className="flex items-center justify-between p-3 border rounded-lg hover:bg-muted/30 transition-colors"
+                >
+                  <div className="flex items-center gap-3">
+                    <div className="h-9 w-9 rounded-full bg-yellow-100 flex items-center justify-center">
+                      <User className="h-4 w-4 text-yellow-600" />
+                    </div>
+                    <div className="space-y-0.5">
+                      <p className="text-sm font-medium">
+                        {child.first_name} {child.last_name}
+                      </p>
+                      {child.email && (
+                        <p className="text-xs text-muted-foreground">
+                          {child.email}
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="text-destructive hover:text-destructive hover:bg-destructive/10"
+                    onClick={() => {
+                      setChildToUnlink(child);
+                      setUnlinkDialogOpen(true);
+                    }}
+                  >
+                    <Unlink className="h-3 w-3 mr-1" />
+                    Unlink
+                  </Button>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Link Child Dialog */}
+      {user?.Jwt && (
+        <LinkChildDialog
+          open={linkDialogOpen}
+          onOpenChange={setLinkDialogOpen}
+          jwt={user.Jwt}
+          onLinkRequested={fetchChildren}
+        />
+      )}
+
+      {/* Unlink Child Confirmation */}
+      <AlertDialog open={unlinkDialogOpen} onOpenChange={setUnlinkDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Unlink Child Account</AlertDialogTitle>
+            <AlertDialogDescription>
+              Are you sure you want to unlink{" "}
+              <strong>
+                {childToUnlink?.first_name} {childToUnlink?.last_name}
+              </strong>{" "}
+              from this parent account? The child&apos;s account will not be
+              deleted, only the parent-child association will be removed.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isUnlinking}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleUnlinkChild}
+              disabled={isUnlinking}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {isUnlinking ? (
+                <Loader2 className="h-4 w-4 animate-spin mr-1" />
+              ) : null}
+              Unlink
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Unlink from Parent Confirmation */}
+      <AlertDialog
+        open={unlinkFromParentDialogOpen}
+        onOpenChange={setUnlinkFromParentDialogOpen}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Unlink from Parent</AlertDialogTitle>
+            <AlertDialogDescription>
+              Are you sure you want to remove the parent association for{" "}
+              <strong>
+                {customer.first_name} {customer.last_name}
+              </strong>
+              ? This will make the account independent.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isUnlinkingFromParent}>
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleUnlinkFromParent}
+              disabled={isUnlinkingFromParent}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {isUnlinkingFromParent ? (
+                <Loader2 className="h-4 w-4 animate-spin mr-1" />
+              ) : null}
+              Unlink
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/services/customer.ts
+++ b/services/customer.ts
@@ -90,6 +90,8 @@ interface CustomerApiResponse {
   scheduled_deletion_at?: string | null;
   archived_at?: string | null;
   days_until_deletion?: number | null;
+  // Parent-child linkage
+  parent_id?: string | null;
 }
 
 // Helper function to map API response to Customer type
@@ -169,6 +171,9 @@ function mapApiResponseToCustomer(response: CustomerApiResponse): Customer {
     scheduled_deletion_at: response.scheduled_deletion_at ?? null,
     archived_at: response.archived_at ?? null,
     days_until_deletion: response.days_until_deletion ?? null,
+
+    // Parent-child linkage
+    parent_id: response.parent_id ?? null,
   };
 
   return customer;
@@ -1428,6 +1433,178 @@ export async function deleteCustomerWaiver(
     }
   } catch (error) {
     console.error(`Error deleting waiver ${waiverId}:`, error);
+    throw error;
+  }
+}
+
+// ============ Family Linkage Functions ============
+
+/**
+ * Get all children linked to a parent by parent_id query param.
+ */
+export async function getChildrenByParentId(
+  parentId: string,
+  jwt: string
+): Promise<Customer[]> {
+  try {
+    const params = new URLSearchParams();
+    params.append("parent_id", parentId);
+    params.append("limit", "20");
+    params.append("offset", "0");
+
+    const url = `${getValue("API")}customers?${params.toString()}`;
+    const response = await fetchWithTokenRefresh(url, {}, jwt);
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch children: ${response.statusText}`);
+    }
+
+    const json: CustomersPaginatedResponse = await response.json();
+    return json.data.map(mapApiResponseToCustomer);
+  } catch (error) {
+    console.error(`Error fetching children for parent ${parentId}:`, error);
+    throw error;
+  }
+}
+
+/**
+ * Admin-only: Unlink a child from their parent.
+ * DELETE /family/admin/link/{childId}
+ */
+export async function adminUnlinkChild(
+  childId: string,
+  jwt: string
+): Promise<string | null> {
+  try {
+    const response = await fetch(`${getValue("API")}family/admin/link/${childId}`, {
+      method: "DELETE",
+      ...addAuthHeader(jwt),
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      return errorData.error || errorData.message || `Failed to unlink: ${response.statusText}`;
+    }
+
+    return null;
+  } catch (error) {
+    console.error(`Error unlinking child ${childId}:`, error);
+    return error instanceof Error ? error.message : "Failed to unlink child";
+  }
+}
+
+/**
+ * Initiate a parent-child link request. Sends email verification to target.
+ * POST /family/link/request
+ */
+export async function requestFamilyLink(
+  targetEmail: string,
+  jwt: string
+): Promise<{ error: string | null; message?: string; requiresOldParent?: boolean }> {
+  try {
+    const response = await fetch(`${getValue("API")}family/link/request`, {
+      method: "POST",
+      ...addAuthHeader(jwt),
+      body: JSON.stringify({ target_email: targetEmail }),
+    });
+
+    const json = await response.json().catch(() => ({}));
+
+    if (!response.ok) {
+      const errorMsg = json.error?.message || json.error || json.message || `Failed to send link request: ${response.statusText}`;
+      return { error: typeof errorMsg === "string" ? errorMsg : String(errorMsg) };
+    }
+
+    return {
+      error: null,
+      message: json.message,
+      requiresOldParent: json.requires_old_parent,
+    };
+  } catch (error) {
+    console.error("Error requesting family link:", error);
+    return { error: error instanceof Error ? error.message : "Failed to send link request" };
+  }
+}
+
+/**
+ * Confirm a link request with verification code.
+ * POST /family/link/confirm
+ */
+export async function confirmFamilyLink(
+  code: string,
+  jwt: string
+): Promise<{ error: string | null; status?: string; message?: string }> {
+  try {
+    const response = await fetch(`${getValue("API")}family/link/confirm`, {
+      method: "POST",
+      ...addAuthHeader(jwt),
+      body: JSON.stringify({ code }),
+    });
+
+    const json = await response.json().catch(() => ({}));
+
+    if (!response.ok) {
+      const errorMsg = json.error?.message || json.error || json.message || `Failed to confirm link: ${response.statusText}`;
+      return { error: typeof errorMsg === "string" ? errorMsg : String(errorMsg) };
+    }
+
+    return {
+      error: null,
+      status: json.status,
+      message: json.message,
+    };
+  } catch (error) {
+    console.error("Error confirming family link:", error);
+    return { error: error instanceof Error ? error.message : "Failed to confirm link" };
+  }
+}
+
+/**
+ * Cancel the caller's pending link request.
+ * DELETE /family/link/request
+ */
+export async function cancelLinkRequest(
+  jwt: string
+): Promise<string | null> {
+  try {
+    const response = await fetch(`${getValue("API")}family/link/request`, {
+      method: "DELETE",
+      ...addAuthHeader(jwt),
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      return errorData.error || errorData.message || `Failed to cancel request: ${response.statusText}`;
+    }
+
+    return null;
+  } catch (error) {
+    console.error("Error cancelling link request:", error);
+    return error instanceof Error ? error.message : "Failed to cancel link request";
+  }
+}
+
+/**
+ * Get all pending link requests for the authenticated user.
+ * GET /family/link/requests
+ */
+export async function getPendingLinkRequests(
+  jwt: string
+): Promise<import("@/types/customer").PendingLinkRequest[]> {
+  try {
+    const response = await fetchWithTokenRefresh(
+      `${getValue("API")}family/link/requests`,
+      {},
+      jwt
+    );
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch link requests: ${response.statusText}`);
+    }
+
+    return await response.json();
+  } catch (error) {
+    console.error("Error fetching pending link requests:", error);
     throw error;
   }
 }

--- a/types/customer.ts
+++ b/types/customer.ts
@@ -55,6 +55,38 @@ export interface Customer {
 
   // Pending email change
   pending_email?: string | null;
+
+  // Parent-child linkage
+  parent_id?: string | null;
+}
+
+export interface FamilyChild {
+  id: string;
+  first_name: string;
+  last_name: string;
+  email: string;
+  linked_at: string;
+}
+
+export interface PendingLinkRequest {
+  id: string;
+  child_id: string;
+  child_name: string;
+  child_email: string;
+  new_parent_id: string;
+  new_parent_name: string;
+  new_parent_email: string;
+  old_parent_id: string;
+  old_parent_name: string;
+  old_parent_email: string;
+  old_parent_verified: boolean;
+  requires_old_parent: boolean;
+  counterparty_verified: boolean;
+  awaiting_user_action: boolean;
+  initiated_by: string;
+  user_role: string;
+  created_at: string;
+  expires_at: string;
 }
 
 export interface CustomerCreditTransaction {


### PR DESCRIPTION


✨ Changes Made

  - Added Family tab to customer info panel showing parent account details and linked children list
  - Added LinkChildDialog for initiating parent-child link requests via email verification flow
  - Added admin unlink functionality using DELETE /family/admin/link/{id} endpoint
  - Added family service functions: getChildrenByParentId, adminUnlinkChild, requestFamilyLink, confirmFamilyLink,
  cancelLinkRequest, getPendingLinkRequests
  - Added parent_id field to Customer type and API response mapping

  ---
  🧠 Reason for Changes

   - Admins need to view and manage parent-child relationships between customer accounts. This uses the new dedicated /family/*
  backend endpoints for proper link/unlink operations instead of directly modifying user records. Linking uses an email
  verification flow where the target user confirms via a code, and unlinking uses the admin-only endpoint for immediate removal.
---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [X] Frontend tested locally (`npm run dev`)
- [X] No console errors (Frontend)

---


# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
- https://trello.com/c/6L7zuqH6/224-family-tab-component
- https://trello.com/c/4bIpmaiR/225-link-child-dialog-email-verification-flow
- https://trello.com/c/D2GRoZyg/226-admin-unlink-via-family-endpoint
- https://trello.com/c/RE5NxaUX/227-add-family-service-functions-and-type-updates

---


