### PR TITLE
[Chore] Update Auth endpoint 

### DIFF
--- a/app/api/Api.ts
+++ b/app/api/Api.ts
@@ -884,17 +884,17 @@ export class Api<
       }),
 
     /**
-     * @description Authenticates a user using Firebase token and returns a JWT token for the authenticated user
+     * @description Authenticates a parent user and returns a JWT token for a linked user
      *
      * @tags authentication
-     * @name ChildCreate
-     * @summary Authenticate a user and return a JWT token
-     * @request POST:/auth/child/{id}
+     * @name LinkedCreate
+     * @summary Authenticate as a linked user
+     * @request POST:/auth/linked/{id}
      * @secure
      */
-    childCreate: (id: string, params: RequestParams = {}) =>
+    linkedCreate: (id: string, params: RequestParams = {}) =>
       this.request<IdentityUserAuthenticationResponseDto, Record<string, any>>({
-        path: `/auth/child/${id}`,
+        path: `/auth/linked/${id}`,
         method: "POST",
         secure: true,
         type: ContentType.Json,

--- a/app/api/docs/swagger.json
+++ b/app/api/docs/swagger.json
@@ -2259,22 +2259,22 @@
         }
       }
     },
-    "/auth/child/{id}": {
+    "/auth/linked/{id}": {
       "post": {
         "security": [
           {
             "Bearer": []
           }
         ],
-        "description": "Authenticates a user using Firebase token and returns a JWT token for the authenticated user",
+        "description": "Authenticates a parent user and returns a JWT token for a linked user",
         "consumes": ["application/json"],
         "produces": ["application/json"],
         "tags": ["authentication"],
-        "summary": "Authenticate a user and return a JWT token",
+        "summary": "Authenticate as a linked user",
         "parameters": [
           {
             "type": "string",
-            "description": "Child ID",
+            "description": "Linked user ID",
             "name": "id",
             "in": "path",
             "required": true


### PR DESCRIPTION
✨ Changes Made

  - Renamed /auth/child/{id} endpoint to /auth/linked/{id} in Api.ts
  - Renamed childCreate method to linkedCreate to match new endpoint
  - Updated swagger docs with latest backend changes (all customer roles now "athlete", no more parent/child JWT roles)

  ---
  🧠 Reason for Changes

  - Backend removed parent/child JWT roles — all customers now authenticate as "athlete" regardless of family relationship.
  Parent-child relationships are tracked via parent_id in the database, not the JWT role. The /auth/child/{id} endpoint was
  renamed to /auth/linked/{id} to reflect this change.
---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [X] Frontend tested locally (`npm run dev`)
- [X] No console errors (Frontend)

---



# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
- https://trello.com/c/ouUawn5b/228-rename-auth-child-to-auth-linked-endpoint

---


